### PR TITLE
Updating formatting to meet Puppet Labs best practices

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,4 +1,12 @@
-class rsyslog::client ($log_remote = true, $remote_type = 'tcp', $log_local = false, $log_auth_local = false, $custom_config = undef, $server = 'log') inherits rsyslog {
+class rsyslog::client (
+  $log_remote     = true,
+  $remote_type    = 'tcp',
+  $log_local      = false,
+  $log_auth_local = false,
+  $custom_config  = undef,
+  $server         = 'log'
+) inherits rsyslog {
+
 	file { $rsyslog::params::client_conf:
 		ensure 	=> present,
 		owner 	=> root,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,15 +1,15 @@
 class rsyslog::params {
   case $::operatingsystem {
     ubuntu, debian: {
-      $rsyslog_package_name = 'rsyslog'
-      $relp_package_name = 'rsyslog-relp'
-      $rsyslog_d = '/etc/rsyslog.d/'
-      $rsyslog_conf = '/etc/rsyslog.conf'
-      $rsyslog_default = '/etc/default/rsyslog'
-      $spool_dir = '/var/spool/rsyslog/'
-      $service_name = 'rsyslog'
-      $client_conf = "${rsyslog_d}client.conf"
-      $server_conf = "${rsyslog_d}server.conf"
+      $rsyslog_package_name   = 'rsyslog'
+      $relp_package_name      = 'rsyslog-relp'
+      $rsyslog_d              = '/etc/rsyslog.d/'
+      $rsyslog_conf           = '/etc/rsyslog.conf'
+      $rsyslog_default        = '/etc/default/rsyslog'
+      $spool_dir              = '/var/spool/rsyslog/'
+      $service_name           = 'rsyslog'
+      $client_conf            = "${rsyslog_d}client.conf"
+      $server_conf            = "${rsyslog_d}server.conf"
     }
     default: {
       fail("Unsupported platform: ${::operatingsystem}")

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,4 +1,11 @@
-class rsyslog::server ($enable_tcp = true, $enable_udp = true, $server_dir = '/srv/log/', $custom_config = undef, $high_precision_timestamps = false) inherits rsyslog {
+class rsyslog::server (
+  $enable_tcp                = true,
+  $enable_udp                = true,
+  $server_dir                = '/srv/log/',
+  $custom_config             = undef,
+  $high_precision_timestamps = false
+) inherits rsyslog {
+
     file { $rsyslog::params::server_conf:
         ensure  => present,
         owner   => root,


### PR DESCRIPTION
Lining up variables and keeping line width under 80 characters for class arguments.
