### PR TITLE
Add server port in rsyslog::client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Manage rsyslog client and server via Puppet
         log_auth_local => false,
         custom_config  => undef,
         server         => 'log',
+        port           => '514',
     }
 ```
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -4,7 +4,8 @@ class rsyslog::client (
   $log_local      = false,
   $log_auth_local = false,
   $custom_config  = undef,
-  $server         = 'log'
+  $server         = 'log',
+  $port           = '514'
 ) inherits rsyslog {
 
   file { $rsyslog::params::client_conf:

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -11,9 +11,9 @@ $ActionResumeRetryCount -1      # infinety retries if host is down
 <% if scope.lookupvar('rsyslog::client::log_remote') -%>
 # Log to remote syslog server using <%= scope.lookupvar('rsyslog::client::remote_type') %>
 <% if scope.lookupvar('rsyslog::client::remote_type') == 'tcp' -%>
-*.* @@<%= scope.lookupvar('rsyslog::client::server') -%>:514;RSYSLOG_ForwardFormat
+*.* @@<%= scope.lookupvar('rsyslog::client::server') -%>:<%= scope.lookupvar('rsyslog::client::port') -%>;RSYSLOG_ForwardFormat
 <% else -%>
-*.* @<%= scope.lookupvar('rsyslog::client::server') -%>:514;RSYSLOG_ForwardFormat
+*.* @<%= scope.lookupvar('rsyslog::client::server') -%>:<%= scope.lookupvar('rsyslog::client::port') -%>;RSYSLOG_ForwardFormat
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
This commit adds port option for the rsyslog::client class for servers
not running on 514.

Awesome job on the module! Cheers!
