### PR TITLE
Why $rsyslog::params::rsyslog_d gets purged?

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,6 @@ class rsyslog::config inherits rsyslog::params {
     ensure  => directory,
     owner   => 'root',
     group   => $rsyslog::params::run_group,
-    purge   => true,
     recurse => true,
     force   => true,
     require => Class['rsyslog::install'],


### PR DESCRIPTION
On Debian (squeeze) when installing other packages (like postfix) some of them add files to /etc/rsyslog.d/

In particular I can't see how to add postfix include to the mix of this module without coupling it with others or coding a specific hack on template.

Postfix include (/etc/rsyslog.d/postfix.conf) looks like:

```
# Create an additional socket in postfix's chroot in order not to break
# mail logging when rsyslog is restarted.  If the directory is missing,
# rsyslog will silently skip creating the socket.
$AddUnixListenSocket /var/spool/postfix/dev/log
```
