### PR TITLE
Add `custom_params` to `rsyslog::client` for custom templates

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -11,6 +11,7 @@
 # [*log_local*]
 # [*log_auth_local*]
 # [*custom_config*]
+# [*custom_params*]
 # [*server*]
 # [*port*]
 #
@@ -27,6 +28,7 @@ class rsyslog::client (
   $log_local      = false,
   $log_auth_local = false,
   $custom_config  = undef,
+  $custom_params  = undef,
   $server         = 'log',
   $port           = '514'
 ) inherits rsyslog {


### PR DESCRIPTION
When doing lookups in templates, variables that are not explicitly
scoped with `scope.lookupvar()` must be in the scope of the `template()`
function call. `rsyslog::client` allows custom templates to be called,
but doesn't allow custom parameters to be passed for the alterate
template to use.

This pull request adds a `custom_params` parameter so a hash of extra
parameters may be passed for the custom template to access without
explicit scoping knowledge.
