### PR TITLE
Expose purge_rsyslog_d as a parameter on the toplevel rsyslog class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class rsyslog (
   $pgsql_package_name     = $rsyslog::params::pgsql_package_name,
   $package_status         = $rsyslog::params::package_status,
   $rsyslog_d              = $rsyslog::params::rsyslog_d,
+  $purge_rsyslog_d        = $rsyslog::params::purge_rsyslog_d,
   $rsyslog_conf           = $rsyslog::params::rsyslog_conf,
   $rsyslog_default        = $rsyslog::params::rsyslog_default,
   $run_user               = $rsyslog::params::run_user,


### PR DESCRIPTION
Sometimes you really do want to purge the rsyslog.d directory. Expose
it as an option.
