### PR TITLE
added trailing slash to rsyslog::server's $server_dir default

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,7 +29,7 @@ class rsyslog::server (
   $enable_tcp                = true,
   $enable_udp                = true,
   $enable_onefile            = false,
-  $server_dir                = '/srv/log',
+  $server_dir                = '/srv/log/',
   $custom_config             = undef,
   $high_precision_timestamps = false
 ) inherits rsyslog {


### PR DESCRIPTION
When I applied `rsyslog::server`, with defaults, logs were ending up as `/srv/log<srcname>/file…` rather than `/srv/log/<srcname>/file…`.  I presume this is incorrect?

Ubuntu 12.04.2, rsyslog package 5.8.6-1ubuntu8.
