### PR TITLE
Updating params to support EL5 packages.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,11 @@ class rsyslog::params {
     }
     redhat: {
       $rsyslog_package_name   = 'rsyslog'
-      $relp_package_name      = 'rsyslog-relp'
+      if $::operatingsystemrelease >= 6.0 {
+       $relp_package_name      = 'rsyslog-relp'
+      } else {
+       $relp_package_name      = 'librelp'
+      }
       $mysql_package_name     = 'rsyslog-mysql'
       $pgsql_package_name     = 'rsyslog-pgsql'
       $package_status         = 'latest'


### PR DESCRIPTION
Greetings,

Thank you for this module! It has saved me a LOT of time. I did discover a problem though. On my RHEL/CentOS/Scientific 5 systems (we have a mix for complicated reasonings) I discovered that I get these errors with puppet:

Error: Could not update: Could not find package rsyslog-relp
Error: /Stage[main]/Rsyslog::Install/Package[rsyslog-relp]/ensure: change from absent to latest failed: Could not update: Could not find package rsyslog-relp
Notice: /Stage[main]/Rsyslog::Config/File[/etc/sysconfig/rsyslog]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/etc/sysconfig/rsyslog]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.conf]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.conf]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.d/]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.d/]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Config/File[/var/lib/rsyslog/]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/var/lib/rsyslog/]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Client/File[/etc/rsyslog.d/client.conf]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Client/File[/etc/rsyslog.d/client.conf]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Service/Service[rsyslog]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Service/Service[rsyslog]: Skipping because of failed dependencies

Errr...

$ sudo yum search relp
[snip headers]
librelp.i386 : The Reliable Event Logging Protocol library
librelp.x86_64 : The Reliable Event Logging Protocol library
librelp-devel.i386 : Development files for the librelp package
librelp-devel.x86_64 : Development files for the librelp package

Huh. No rsyslog-relp packages on EL5. :-/

A quick search on the Internet for an answer led me to 2 possibilities:
1) librelp _should_ work.
2) Use IUSCommunity packages. http://dl.iuscommunity.org/pub/ius/stable/CentOS/5/x86_64/repoview/letter_r.group.html

In either case, the name of the file needs to change for version 5 and I would prefer not to add a new repo for just one package. So I made this change for librelp.

This is how I fixed the problem. In my testing it appears to be working without issue (though I must admit it is fairly limited testing at the moment; we are planning on pushing this change to more servers after the module makes its way through the dev environment). I would be grateful if you could pull the changes in for your next release.

Thank you!
