### PR TITLE
Need to specificly define high precision time format

### DIFF
--- a/templates/server/_default-header.conf.erb
+++ b/templates/server/_default-header.conf.erb
@@ -8,12 +8,15 @@ $ModLoad imudp
 $ModLoad imtcp
 <% end -%>
 
-<% if scope.lookupvar('rsyslog::server::high_precision_timestamps') == false -%>
 #
+<% if scope.lookupvar('rsyslog::server::high_precision_timestamps') == false -%>
 # Use traditional timestamp format.
-# To enable high precision timestamps, comment out the following line.
 #
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+<% else -%>
+# Use high precision timestamp format.
+#
+$ActionFileDefaultTemplate RSYSLOG_FileFormat
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::ssl') -%>


### PR DESCRIPTION
incase of using both client and server config on same rsyslog instance. Otherwise it will inherit the traditional format from the client config.
