### PR TITLE
use @ global variable in erb

### DIFF
--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -6,6 +6,6 @@ $InputFileStateFile state-<%= @name %>
 $InputFileSeverity <%= @file_severity %>
 $InputFileFacility <%= @file_facility %>
 $InputFilePollInterval <%= @polling_interval %>
-<% if run_file_monitor == true -%>
+<% if @run_file_monitor == true -%>
 $InputRunFileMonitor
 <% end -%>


### PR DESCRIPTION
Suppress warnings complaining about non-'@' variable
