### PR TITLE
Preserve FQDN parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Manage rsyslog client and server via Puppet
         custom_config  => undef,
         server         => 'log',
         port           => '514',
+        preserve_fqdn  => undef,
     }
 ```
 for read from file
@@ -88,6 +89,7 @@ The following lists all the class parameters this module accepts.
     server_dir                          STRING              Folder where logs will be stored on the server. Defaults to '/srv/log/'
     custom_config                       STRING              Specify your own template to use for server config. Defaults to undef. Example usage: custom_config => 'rsyslog/my_config.erb'
     high_precision_timestamps           true,false          Whether or not to use high precision timestamps.
+    preserve_fqdn                       true,false          Whether or not to preserve the fully qualified domain name when logging.
 
     RSYSLOG::CLIENT CLASS PARAMETERS    VALUES              DESCRIPTION
     -------------------------------------------------------------------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,6 +15,7 @@
 # [*server*]
 # [*port*]
 # [*ssl_ca*]
+# [*preserve_fqdn]
 #
 # === Variables
 #
@@ -32,7 +33,8 @@ class rsyslog::client (
   $custom_params  = undef,
   $server         = 'log',
   $port           = '514',
-  $ssl_ca         = undef
+  $ssl_ca         = undef,
+  $preserve_fqdn  = undef
 ) inherits rsyslog {
 
   $content_real = $custom_config ? {

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -41,6 +41,11 @@ auth,authpriv.*                 /var/log/secure
 <% end -%>
 <% end -%>
 
+<% if scope.lookupvar('rsyslog::client::preserve_fqdn') -%>
+# Tell rsyslog to use FQDN and not short server names
+$PreserveFQDN on 
+<% end -%>
+
 <% if scope.lookupvar('rsyslog::client::log_local') -%>
 <% if scope.lookupvar('rsyslog::log_style') == 'debian' -%>
 # First some standard log files.  Log by facility.


### PR DESCRIPTION
Sets the `$PreserveFQDN` parameter which enables logging with the client's fully qualified domain name.
