### PR TITLE
Specify the default logging format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The following lists all the class parameters this module accepts.
     custom_config                       STRING              Specify your own template to use for server config. Defaults to undef. Example usage: custom_config => 'rsyslog/my_config.erb'
     high_precision_timestamps           true,false          Whether or not to use high precision timestamps.
     preserve_fqdn                       true,false          Whether or not to preserve the fully qualified domain name when logging.
+    actionfiletemplate                  STRING              If set this defines the `ActionFileDefaultTemplate` which sets the default logging format for remote and local logging..
 
     RSYSLOG::CLIENT CLASS PARAMETERS    VALUES              DESCRIPTION
     -------------------------------------------------------------------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,7 +15,7 @@
 # [*server*]
 # [*port*]
 # [*ssl_ca*]
-# [*preserve_fqdn]
+# [*actionfiletemplate*]
 #
 # === Variables
 #
@@ -24,17 +24,18 @@
 #  class { 'rsyslog::client': }
 #
 class rsyslog::client (
-  $log_remote     = true,
-  $spool_size     = '1g',
-  $remote_type    = 'tcp',
-  $log_local      = false,
-  $log_auth_local = false,
-  $custom_config  = undef,
-  $custom_params  = undef,
-  $server         = 'log',
-  $port           = '514',
-  $ssl_ca         = undef,
-  $preserve_fqdn  = undef
+  $log_remote         = true,
+  $spool_size         = '1g',
+  $remote_type        = 'tcp',
+  $log_local          = false,
+  $log_auth_local     = false,
+  $custom_config      = undef,
+  $custom_params      = undef,
+  $server             = 'log',
+  $port               = '514',
+  $ssl_ca             = undef,
+  $actionfiletemplate = undef,
+  $preserve_fqdn      = undef
 ) inherits rsyslog {
 
   $content_real = $custom_config ? {

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -7,7 +7,14 @@ $ActionQueueMaxDiskSpace <%= scope.lookupvar('rsyslog::client::spool_size') -%> 
 $ActionQueueSaveOnShutdown on   # save messages to disk on shutdown
 $ActionQueueType LinkedList     # run asynchronously
 $ActionResumeRetryCount -1      # infinety retries if host is down
-
+<% if scope.lookupvar('rsyslog::client::actionfiletemplate') -%>
+# Using specified format for default logging fromat:
+$ActionFileDefaultTemplate <%= scope.lookupvar('rsyslog::client::actionfiletemplate') %>
+<% else -%>
+#Using default format for default logging fromat:
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+<% end -%>
+<% if scope.lookupvar('rsyslog::client::log_auth_local') or scope.lookupvar('rsyslog::client::log_local') -%>
 <% if scope.lookupvar('rsyslog::client::ssl') -%>
 # Setup SSL connection.
 # CA/Cert
@@ -28,9 +35,7 @@ $ActionSendStreamDriverAuthMode anon
 <% end -%>
 <% end -%>
 
-<% if scope.lookupvar('rsyslog::client::log_auth_local') or scope.lookupvar('rsyslog::client::log_local') -%>
-# We log locally, restore to default format
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+# Logging locally.
 
 <% if scope.lookupvar('rsyslog::log_style') == 'debian' -%>
 # Log auth messages locally


### PR DESCRIPTION
new parameter rsyslog::client parameter, actionfiletemplate, which sets the default logging format for remote and local logging.
