### PR TITLE
Configuring mulitple remote servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,45 @@ for read from file
 
 ```
 
+#### Logging to multiple remote servers
+
+The `remote_servers` parameter can be used to set up logging to multiple remote servers which are supplied as a list of key value pairs for each remote. There is an example configuration provided in `./test/multiple_hosts.pp`
+
+Using the `remote_servers` parameter over-rides the other remote sever parameters, and they will not be used in the client configuration file:
+* `log_remote`
+* `remote_type`
+* `server`
+* `port`
+
+The following example sets up three remote logging hosts for the client:
+
+```puppet
+class{'rsyslog::client':
+  remote_servers => [
+    {
+      host => 'logs.example.org',
+    },
+    {
+      port => '55514',
+    },
+    {
+      host      => 'logs.somewhere.com',
+      port      => '555',
+      pattern   => '*.log',
+      protocol  => 'tcp',
+      format    => 'RFC3164fmt',
+    },
+  ]
+}
+```
+
+Each host has the following parameters:
+* *host*: Sets the address or hostname of the remote logging server. Defaults to `localhost`
+* *port*: Sets the port the host is listening on. Defaults to `514`
+* *pattern*: Sets the pattern to match logs. Defaults to `*.*`
+* *protocol*: Sets the protocol. Only recognises TCP and UDP. Defaults to UDP
+* *format*: Sets the log format. Defaults to not specifying log format, which defaults to the format set by `ActionFileDefaultTemplate` in the client configuration.
+
 #### Logging to a MySQL or PostgreSQL database
 
 Events can also be logged to a MySQL or PostgreSQL database. The database needs to be deployed separately, either locally or remotely. Schema are available from the `rsyslog` source:
@@ -91,6 +130,7 @@ The following lists all the class parameters this module accepts.
     high_precision_timestamps           true,false          Whether or not to use high precision timestamps.
     preserve_fqdn                       true,false          Whether or not to preserve the fully qualified domain name when logging.
     actionfiletemplate                  STRING              If set this defines the `ActionFileDefaultTemplate` which sets the default logging format for remote and local logging..
+    remote_servers                      HASH                Provides a hash of multiple remote logging servers. Check documentation.
 
     RSYSLOG::CLIENT CLASS PARAMETERS    VALUES              DESCRIPTION
     -------------------------------------------------------------------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -5,15 +5,16 @@
 # === Parameters
 #
 # [*sample_parameter*]
-# [*log_remote*]
 # [*spool_size*]
-# [*remote_type*]
 # [*log_local*]
 # [*log_auth_local*]
 # [*custom_config*]
 # [*custom_params*]
+# [*log_remote*]
 # [*server*]
+# [*remote_type*]
 # [*port*]
+# [*remote_servers*]
 # [*ssl_ca*]
 # [*actionfiletemplate*]
 #
@@ -33,9 +34,10 @@ class rsyslog::client (
   $custom_params      = undef,
   $server             = 'log',
   $port               = '514',
+  $remote_servers     = false,
   $ssl_ca             = undef,
-  $actionfiletemplate = undef,
-  $preserve_fqdn      = undef
+  $actionfiletemplate = false,
+  $preserve_fqdn      = false
 ) inherits rsyslog {
 
   $content_real = $custom_config ? {

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -14,6 +14,48 @@ $ActionFileDefaultTemplate <%= scope.lookupvar('rsyslog::client::actionfiletempl
 #Using default format for default logging fromat:
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 <% end -%>
+<% if scope.lookupvar('rsyslog::client::remote_servers') and ! scope.lookupvar('rsyslog::client::remote_servers').empty? -%>
+<% scope.lookupvar('rsyslog::client::remote_servers').flatten.compact.each do |server| -%>
+<% if server['pattern'] and server['pattern'] != ''-%>
+<% pattern = server['pattern'] -%>
+<% else -%>
+<% pattern = '*.*' -%>
+<% end -%>
+<% if server['protocol'] == 'TCP' or server['protocol'] == 'tcp'-%>
+<% protocol = '@@' -%>
+<% protocol_type = 'TCP' -%>
+<% else -%>
+<% protocol = '@' -%>
+<% protocol_type = 'UDP' -%>
+<% end -%>
+<% if server['host'] and server['host'] != ''-%>
+<% host = server['host'] -%>
+<% else -%>
+<% host = 'localhost' -%>
+<% end -%>
+<% if server['port'] and server['port'] != ''-%>
+<% port = server['port'] -%>
+<% else -%>
+<% port = '514' -%>
+<% end -%>
+<% if server['format'] -%>
+<% format = ";#{server['format']}" -%>
+<% format_type = server['format'] -%>
+<% else -%>
+<% format = '' -%>
+<% format_type = 'the default' -%>
+<% end -%>
+# Sending logs that match <%= pattern %> to <%= host %> via <%= protocol_type %> on <%= port %> using <%=format_type %> format.
+<%= pattern %> <%= protocol %><%= host %>:<%= port %><%= format %>
+<% end -%>
+<% elsif scope.lookupvar('rsyslog::client::log_remote') -%>
+# Log to remote syslog server using <%= scope.lookupvar('rsyslog::client::remote_type') %>
+<% if scope.lookupvar('rsyslog::client::remote_type') == 'tcp' -%>
+*.* @@<%= scope.lookupvar('rsyslog::client::server') -%>:<%= scope.lookupvar('rsyslog::client::port') -%>;RSYSLOG_ForwardFormat
+<% else -%>
+*.* @<%= scope.lookupvar('rsyslog::client::server') -%>:<%= scope.lookupvar('rsyslog::client::port') -%>;RSYSLOG_ForwardFormat
+<% end -%>
+<% end -%>
 <% if scope.lookupvar('rsyslog::client::log_auth_local') or scope.lookupvar('rsyslog::client::log_local') -%>
 <% if scope.lookupvar('rsyslog::client::ssl') -%>
 # Setup SSL connection.
@@ -24,15 +66,6 @@ $DefaultNetStreamDriverCAFile <%= scope.lookupvar('rsyslog::client::ssl_ca') %>
 $DefaultNetstreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode anon
-<% end -%>
-
-<% if scope.lookupvar('rsyslog::client::log_remote') -%>
-# Log to remote syslog server using <%= scope.lookupvar('rsyslog::client::remote_type') %>
-<% if scope.lookupvar('rsyslog::client::remote_type') == 'tcp' -%>
-*.* @@<%= scope.lookupvar('rsyslog::client::server') -%>:<%= scope.lookupvar('rsyslog::client::port') -%>;RSYSLOG_ForwardFormat
-<% else -%>
-*.* @<%= scope.lookupvar('rsyslog::client::server') -%>:<%= scope.lookupvar('rsyslog::client::port') -%>;RSYSLOG_ForwardFormat
-<% end -%>
 <% end -%>
 
 # Logging locally.

--- a/tests/multiple_hosts.pp
+++ b/tests/multiple_hosts.pp
@@ -1,0 +1,17 @@
+class{'rsyslog::client':
+  remote_servers => [
+    {
+      host => 'logs.example.org',
+    },
+    {
+      port => '55514',
+    },
+    {
+      host      => 'logs.somewhere.com',
+      port      => '555',
+      pattern   => '*.log',
+      protocol  => 'tcp',
+      format    => 'RFC3164fmt',
+    },
+  ]
+}


### PR DESCRIPTION
This configures multiple remote servers provided as a list of key/value pairs. Supplying such a list over-rides the usual method of providing a single remote server.

This new method also allows each server to specify the log matching pattern, the protocol, host, port, and log format.

It should be backwards compatible with the previous single remote method and not trigger a new major version.
