### PR TITLE
PreserveFQDN as first directive in rsyslog.conf

### DIFF
--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -33,11 +33,6 @@ $DefaultNetstreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode anon
 <% end -%>
-<% if scope.lookupvar('rsyslog::client::preserve_fqdn') -%>
-
-# Tell rsyslog to use FQDN and not short server names
-$PreserveFQDN on 
-<% end -%>
 <% if scope.lookupvar('rsyslog::client::remote_servers')  -%>
 
 <% scope.lookupvar('rsyslog::client::remote_servers').flatten.compact.each do |server| -%>

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -14,6 +14,9 @@
 #
 # Set the default permissions for all log files.
 #
+<% if scope.lookupvar('rsyslog::client::preserve_fqdn') -%>
+$PreserveFQDN on
+<% end -%>
 $FileOwner <%= scope.lookupvar('rsyslog::log_user') %>
 $FileGroup <%= scope.lookupvar('rsyslog::log_group') %>
 $FileCreateMode <%= scope.lookupvar('rsyslog::perm_file') %>


### PR DESCRIPTION
PreserveFQDN moved from client.conf.erb to rsyslog.conf.erb template. Fixes #66.
