### PR TITLE
Handle Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,14 @@ class rsyslog::params {
       ]
     }
     redhat: {
-      if ($::operatingsystem == 'Amazon') or ($::operatingsystemrelease >= 6.0) {
+      if $::operatingsystem == 'Amazon' {
+        $rsyslog_package_name   = 'rsyslog'
+        $mysql_package_name     = 'rsyslog-mysql'
+        $pgsql_package_name     = 'rsyslog-pgsql'
+        $gnutls_package_name    = 'rsyslog-gnutls'
+        $relp_package_name      = false
+      }
+      elsif $::operatingsystemrelease >= 6.0 {
         $rsyslog_package_name   = 'rsyslog'
         $mysql_package_name     = 'rsyslog-mysql'
         $pgsql_package_name     = 'rsyslog-pgsql'


### PR DESCRIPTION
Facter in amazon linux gives:
     operatingsystemrelease => 3.4.62-53.42.amzn1.x86_64
this breaks the comparison (string vs float)

This commit isn't the prettiest way of doing it, but it works.
