### PR TITLE
Set default for $purge_rsyslog_d on RedHat (required when strict_variabl...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,7 @@ class rsyslog::params {
       }
       $package_status         = 'latest'
       $rsyslog_d              = '/etc/rsyslog.d/'
+      $purge_rsyslog_d        = false
       $rsyslog_conf           = '/etc/rsyslog.conf'
       $rsyslog_default        = '/etc/sysconfig/rsyslog'
       $default_config_file    = 'rsyslog_default'


### PR DESCRIPTION
...es is on)
