### PR TITLE
imfile: Add the persist_state_interval option

### DIFF
--- a/manifests/imfile.pp
+++ b/manifests/imfile.pp
@@ -10,6 +10,7 @@
 # [*polling_interval*]
 # [*file_severity*]
 # [*run_file_monitor*]
+# [*persist_state_interval]
 #
 # === Variables
 #
@@ -27,7 +28,8 @@ define rsyslog::imfile(
   $file_facility,
   $polling_interval = 10,
   $file_severity = 'notice',
-  $run_file_monitor = true
+  $run_file_monitor = true,
+  $persist_state_interval = 0
 ) {
 
   include rsyslog

--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -6,6 +6,7 @@ $InputFileStateFile state-<%= @name %>
 $InputFileSeverity <%= @file_severity %>
 $InputFileFacility <%= @file_facility %>
 $InputFilePollInterval <%= @polling_interval %>
+$InputFilePersistStateInterval <%= @persist_state_interval %>
 <% if @run_file_monitor == true -%>
 $InputRunFileMonitor
 <% end -%>


### PR DESCRIPTION
This adds an option to imfile so that the InputFilePersistStateInterval variable can be configured. The value defaults to 0, which is also what rsyslog will default to if the value is not specified. (According to http://www.rsyslog.com/doc/imfile.html)
