### PR TITLE
add support for RHEL 7 #85

### DIFF
--- a/files/rsyslog_default_rhel7
+++ b/files/rsyslog_default_rhel7
@@ -1,0 +1,2 @@
+# File is managed by puppet
+SYSLOGD_OPTIONS=""

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,26 +53,57 @@ class rsyslog::params {
         $pgsql_package_name     = 'rsyslog-pgsql'
         $gnutls_package_name    = 'rsyslog-gnutls'
         $relp_package_name      = false
+        $default_config_file    = 'rsyslog_default'
+        $modules                = [
+          '$ModLoad imuxsock # provides support for local system logging',
+          '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
+          '#$ModLoad immark  # provides --MARK-- message capability',
+        ]
       }
-      elsif $::operatingsystemrelease >= 6.0 {
+      elsif $::operatingsystemmajrelease == 6 {
         $rsyslog_package_name   = 'rsyslog'
         $mysql_package_name     = 'rsyslog-mysql'
         $pgsql_package_name     = 'rsyslog-pgsql'
         $gnutls_package_name    = 'rsyslog-gnutls'
         $relp_package_name      = 'rsyslog-relp'
+        $default_config_file    = 'rsyslog_default'
+        $modules                = [
+          '$ModLoad imuxsock # provides support for local system logging',
+          '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
+          '#$ModLoad immark  # provides --MARK-- message capability',
+        ]
+      }
+      elsif $::operatingsystemmajrelease >= 7 {
+        $rsyslog_package_name   = 'rsyslog'
+        $mysql_package_name     = 'rsyslog-mysql'
+        $pgsql_package_name     = 'rsyslog-pgsql'
+        $gnutls_package_name    = 'rsyslog-gnutls'
+        $relp_package_name      = 'rsyslog-relp'
+        $default_config_file    = 'rsyslog_default_rhel7'
+        $modules                = [
+          '$ModLoad imuxsock # provides support for local system logging',
+          '$ModLoad imjournal # provides access to the systemd journal',
+          '#$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
+          '#$ModLoad immark  # provides --MARK-- message capability',
+        ]
       } else {
         $rsyslog_package_name   = 'rsyslog5'
         $mysql_package_name     = 'rsyslog5-mysql'
         $pgsql_package_name     = 'rsyslog5-pgsql'
         $gnutls_package_name    = 'rsyslog5-gnutls'
         $relp_package_name      = 'librelp'
+        $default_config_file    = 'rsyslog_default'
+        $modules                = [
+          '$ModLoad imuxsock # provides support for local system logging',
+          '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
+          '#$ModLoad immark  # provides --MARK-- message capability',
+        ]
       }
       $package_status         = 'latest'
       $rsyslog_d              = '/etc/rsyslog.d/'
       $purge_rsyslog_d        = false
       $rsyslog_conf           = '/etc/rsyslog.conf'
       $rsyslog_default        = '/etc/sysconfig/rsyslog'
-      $default_config_file    = 'rsyslog_default'
       $run_user               = 'root'
       $run_group              = 'root'
       $log_user               = 'root'
@@ -85,11 +116,6 @@ class rsyslog::params {
       $client_conf            = 'client'
       $server_conf            = 'server'
       $ssl                    = false
-      $modules                = [
-        '$ModLoad imuxsock # provides support for local system logging',
-        '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
-        '#$ModLoad immark  # provides --MARK-- message capability',
-      ]
       $preserve_fqdn          = false
       $service_hasrestart     = true
       $service_hasstatus      = true

--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -6,7 +6,7 @@ describe 'rsyslog::client', :type => :class do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 

--- a/spec/classes/rsyslog_database_spec.rb
+++ b/spec/classes/rsyslog_database_spec.rb
@@ -6,7 +6,7 @@ describe 'rsyslog::database', :type => :class do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 

--- a/spec/classes/rsyslog_server_spec.rb
+++ b/spec/classes/rsyslog_server_spec.rb
@@ -8,7 +8,7 @@ describe 'rsyslog::server', :type => :class do
         {
           :osfamily               => osfamily,
           :operatingsystem        => osfamily,
-          :operatingsystemrelease => 6.0,
+          :operatingsystemmajrelease => 6,
         }
       end
 

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -6,7 +6,7 @@ describe 'rsyslog', :type => :class do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 
@@ -62,7 +62,7 @@ describe 'rsyslog', :type => :class do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 
@@ -115,7 +115,7 @@ describe 'rsyslog', :type => :class do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 
@@ -168,7 +168,7 @@ describe 'rsyslog', :type => :class do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 

--- a/spec/defines/rsyslog_imfile_spec.rb
+++ b/spec/defines/rsyslog_imfile_spec.rb
@@ -6,7 +6,7 @@ describe 'rsyslog::imfile', :type => :define do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 

--- a/spec/defines/rsyslog_snippet_spec.rb
+++ b/spec/defines/rsyslog_snippet_spec.rb
@@ -6,7 +6,7 @@ describe 'rsyslog::snippet', :type => :define do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'Redhat',
-        :operatingsystemrelease => 6.0,
+        :operatingsystemmajrelease => 6,
       }
     end
 


### PR DESCRIPTION
The addition of systemd in RHEL 7 requires both a change for the default file, to remove any bash constructs, and the addition of the imjournal module.

This allows rsyslog to start up correctly on RHEL7.
