### PR TITLE
Fix error in template if rsyslog_version fact is not present

### DIFF
--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -117,4 +117,30 @@ describe 'rsyslog::client', :type => :class do
       end
     end
   end
+
+  context "Rsyslog version = nil" do
+    let(:default_facts) do
+      {
+        :rsyslog_version => nil
+      }
+    end
+
+    context "osfamily = RedHat" do
+      let :facts do
+        default_facts.merge!({
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemmajrelease => 6,
+        })
+      end
+
+      context "default usage (osfamily = RedHat)" do
+        let(:title) { 'rsyslog-client-basic' }
+
+        it 'should compile' do
+          should contain_file('/etc/rsyslog.d/client.conf')
+        end
+      end
+    end
+  end
 end

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -442,4 +442,28 @@ describe 'rsyslog', :type => :class do
     end
   end
 
+  context "Rsyslog version >= 8" do
+    let(:default_facts) do
+      {
+        :rsyslog_version => nil
+      }
+    end
+
+    context "osfamily = RedHat" do
+      let :facts do
+        default_facts.merge!({
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemmajrelease => 6,
+        })
+      end
+
+      context "default usage (osfamily = RedHat)" do
+        it 'should compile' do
+          should contain_file('/etc/rsyslog.conf')
+          should contain_file('/etc/rsyslog.d/')
+        end
+      end
+    end
+  end
 end

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -165,7 +165,7 @@ mail.*                         -/var/log/maillog
 cron.*                         /var/log/cron
 
 # Everybody gets emergency messages
-<% if @rsyslog_version.split('.')[0].to_i >= 8 -%>
+<% if @rsyslog_version and @rsyslog_version.split('.')[0].to_i >= 8 -%>
 *.emerg       :omusrmsg:*
 <% else -%>
 *.emerg				*

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -35,7 +35,7 @@ $IncludeConfig <%= scope.lookupvar('rsyslog::rsyslog_d') -%>*.conf
 #
 # Emergencies are sent to everybody logged in.
 #
-<% if @rsyslog_version.split('.')[0].to_i >= 8 -%>
+<% if @rsyslog_version and @rsyslog_version.split('.')[0].to_i >= 8 -%>
 *.emerg       :omusrmsg:*
 <% else -%>
 *.emerg				*


### PR DESCRIPTION
Below is the error when rsyslog_version is not present.  I ran into this when unit testing another module that has this one as a fixture and I had not added rsyslog_version to the unit test facts.  I consider this more of a safety precaution.

This is the error when adding the unit tests in this PR while the changes to the templates were stashed

```
     Failure/Error: should contain_file('/etc/rsyslog.conf')
     Puppet::Error:
       Failed to parse template rsyslog/rsyslog.conf.erb:
         Filepath: /Users/treydock/puppet/modules/rsyslog/spec/fixtures/modules/rsyslog/templates/rsyslog.conf.erb
         Line: 38
         Detail: private method `split' called for nil:NilClass
```
