### PR TITLE
Load the imfile module in a separate conf file

### DIFF
--- a/manifests/imfile.pp
+++ b/manifests/imfile.pp
@@ -33,6 +33,7 @@ define rsyslog::imfile(
 ) {
 
   include rsyslog
+  include rsyslog::load_imfile
 
   file { "${rsyslog::rsyslog_d}${name}.conf":
     ensure  => file,

--- a/manifests/load_imfile.pp
+++ b/manifests/load_imfile.pp
@@ -1,0 +1,10 @@
+# == Define: rsyslog::load_imfile
+#
+# This class creates a configuration file to load the imfile module.
+#
+class rsyslog::load_imfile {
+
+  rsyslog::snippet{ '01-load_imfile':
+    content => template('rsyslog/load_imfile.erb'),
+  }
+}

--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -1,5 +1,3 @@
-$ModLoad imfile
-
 $InputFileName <%= @file_name %>
 $InputFileTag <%= @file_tag %>
 $InputFileStateFile state-<%= @name %>

--- a/templates/load_imfile.erb
+++ b/templates/load_imfile.erb
@@ -1,0 +1,1 @@
+$ModLoad imfile


### PR DESCRIPTION
The `LoadMod imfile` line, within the `imfile.erb` template is responsible for loading the imfile module.
However, if multiple configuration files are generated from the same template, the application throws the following warning:

```
2014-07-15T17:02:32.927594+00:00 simon-test rsyslogd-2221: module 'imfile' already in this config, cannot be added [try http://www.rsyslog.com/e/2221 ] 
```

In order to fix this, `LoadMod imfile` has been removed from `imfile.erb` and added into a separate template `load_imfile.erb`. This generates a unique configuration file whenever the `rsyslog::imfile` define is called.

The '01-' suffix within the file name ensures that rsyslog loads the _imfile module_ before reading the _imfile_ configuration files.

The behaviour of the module is unchanged.
