### PR TITLE
Fix Issue #92 setting the perm_file => '0640', and  perm_dir => '0750', params do not take effect.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class rsyslog (
   $log_user               = $rsyslog::params::log_user,
   $log_group              = $rsyslog::params::log_group,
   $log_style              = $rsyslog::params::log_style,
+  $umask                  = $rsyslog::params::umask,
   $perm_file              = $rsyslog::params::perm_file,
   $perm_dir               = $rsyslog::params::perm_dir,
   $spool_dir              = $rsyslog::params::spool_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,6 +109,7 @@ class rsyslog::params {
       $log_user               = 'root'
       $log_group              = 'root'
       $log_style              = 'redhat'
+      $umask                  = '0000'
       $perm_file              = '0600'
       $perm_dir               = '0750'
       $spool_dir              = '/var/lib/rsyslog'

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -26,6 +26,7 @@ $DirGroup <%= scope.lookupvar('rsyslog::log_group') %>
 $DirCreateMode <%= scope.lookupvar('rsyslog::perm_dir') %>
 $PrivDropToUser <%= scope.lookupvar('rsyslog::run_user') %>
 $PrivDropToGroup <%= scope.lookupvar('rsyslog::run_group') %>
+$Umask <%= scope.lookupvar('rsyslog::umask') %>
 
 #
 # Include all config files in <%= scope.lookupvar('rsyslog::rsyslog_d') %>


### PR DESCRIPTION
setting the perm_file => '0640', and  perm_dir => '0750', params do not take effect.
As they are overridden by the umask of the the rsyslog process. This is typically set by RHEL rsyslog init script. This can be resolved by setting the $Umask paramater to 0000.

It is well documented here:
http://www.rsyslog.com/doc/rsconf1_filecreatemode.html
