### PR TITLE
use a simpler spec_helper.rb, which permits tests to run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,28 +1,2 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-RSpec.configure do |c|
-  c.mock_with :rspec do |mock|
-    mock.syntax = [:expect, :should]
-  end
-  c.include PuppetlabsSpec::Files
-
-  c.before :each do
-    # Ensure that we don't accidentally cache facts and environment
-    # between test cases.
-    Facter::Util::Loader.any_instance.stubs(:load_all)
-    Facter.clear
-    Facter.clear_messages
-
-    # Store any environment variables away to be restored later
-    @old_env = {}
-    ENV.each_key {|k| @old_env[k] = ENV[k]}
-
-    if Gem::Version.new(`puppet --version`) >= Gem::Version.new('3.5')
-      Puppet.settings[:strict_variables]=true
-    end
-  end
-
-  c.after :each do
-    PuppetlabsSpec::Files.cleanup
-  end
-end
+Puppet.settings[:confdir] = "spec/fixtures"


### PR DESCRIPTION
on my development system, the current spec_helper doesn't generate working tests. Every test fails with 

```
ArgumentError:
       wrong number of arguments (1 for 0)
```

This spec_helper permits all tests to run (successfully)
