### PR TITLE
set spool_dir seltype to syslogd_var_lib_t

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,7 @@ class rsyslog::config {
     ensure  => directory,
     owner   => 'root',
     group   => $rsyslog::run_group,
+    seltype => 'syslogd_var_lib_t',
     require => Class['rsyslog::install'],
     notify  => Class['rsyslog::service'],
   }


### PR DESCRIPTION
This type is necessary for rsyslogd to be able to write in spool_dir
when selinux is enabled and enforcing. For some reason, this directory
does not have the correct seltype in RHEL <= 7 and using disk queues or
.state files does not work.
