### PR TITLE
moved $PreserveFQDN at the top

### DIFF
--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -1,5 +1,7 @@
 # file is managed by puppet
-
+<% if scope.lookupvar('rsyslog::preserve_fqdn') -%>
+$PreserveFQDN on
+<% end -%>
 #################
 #### MODULES ####
 #################
@@ -19,9 +21,6 @@ $MaxMessageSize <%= scope.lookupvar('rsyslog::max_message_size') %>
 #
 # Set the default permissions for all log files.
 #
-<% if scope.lookupvar('rsyslog::preserve_fqdn') -%>
-$PreserveFQDN on
-<% end -%>
 $FileOwner <%= scope.lookupvar('rsyslog::log_user') %>
 $FileGroup <%= scope.lookupvar('rsyslog::log_group') %>
 $FileCreateMode <%= scope.lookupvar('rsyslog::perm_file') %>


### PR DESCRIPTION
This statement should be the first. As explained at https://wiki.archlinux.org/index.php/rsyslog:
"If you want to have full hostnames in logs, you need to add $PreserveFQDN on to the beginning of the file (before using any directive that write to files). This is because, rsyslog reads config file and applies it on-the-go and then reads the later lines."
