### PR TITLE
Set $rsyslog::spool_dir owner to be $rsyslog::run_user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,7 +41,7 @@ class rsyslog::config {
 
   file { $rsyslog::spool_dir:
     ensure  => directory,
-    owner   => 'root',
+    owner   => $rsyslog::run_user,
     group   => $rsyslog::run_group,
     seltype => 'syslogd_var_lib_t',
     require => Class['rsyslog::install'],


### PR DESCRIPTION
This goes with my previous pull request fixin Ubuntu owner/group.
Then obviously the spool owner must be adjusted accordingly.
This fixes it while keeping previous behaviour (ie root owned) for other systems
