### PR TITLE
Config files owner should be root always

### DIFF
--- a/manifests/snippet.pp
+++ b/manifests/snippet.pp
@@ -25,8 +25,8 @@ define rsyslog::snippet(
 
   file { "${rsyslog::rsyslog_d}${name}.conf":
     ensure  => $ensure,
-    owner   => $rsyslog::run_user,
-    group   => $rsyslog::run_group,
+    owner   => 'root',
+    group   => 'root',
     content => "# This file is managed by Puppet, changes may be overwritten\n${content}\n",
     require => Class['rsyslog::config'],
     notify  => Class['rsyslog::service'],


### PR DESCRIPTION
Config files should be owned by root as much as possible.
This was not and issue until now because  $rsyslog::run_user was always root, but my other pull-request make this not true anymore