### PR TITLE
Implemented rsyslog rate limiting settings for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The following lists all the class parameters this module accepts.
     log_templates                       HASH                Provides a has defining custom logging templates using the `$template` configuration parameter.
     actionfiletemplate                  STRING              If set this defines the `ActionFileDefaultTemplate` which sets the default logging format for remote and local logging.
     high_precision_timestamps           true,false          Whether or not to use high precision timestamps.
+    rate_limit_burst                    INTEGER             Specifies the number of messages in $rate_limit_interval before limiting begins. Defaults to undef.
+    rate_limit_interval                 INTEGER             Specifies the number of seconds per rate limit interval. Defaults to undef.
 
     RSYSLOG::DATABASE CLASS PARAMETERS  VALUES              DESCRIPTION
     -------------------------------------------------------------------

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,6 +18,8 @@
 # [*ssl_ca*]
 # [*log_templates*]
 # [*actionfiletemplate*]
+# [*rate_limit_burst*]
+# [*rate_limit_interval*]
 #
 # === Variables
 #
@@ -40,7 +42,9 @@ class rsyslog::client (
   $ssl_ca                    = undef,
   $log_templates             = false,
   $actionfiletemplate        = false,
-  $high_precision_timestamps = false
+  $high_precision_timestamps = false,
+  $rate_limit_burst          = undef,
+  $rate_limit_interval       = undef
 ) inherits rsyslog {
 
   if $custom_config {

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -28,6 +28,13 @@ $ActionFileDefaultTemplate RSYSLOG_FileFormat
 <% end -%>
 <% end -%>
 
+<% if scope.lookupvar('rsyslog::client::rate_limit_burst') -%>
+$SystemLogRateLimitBurst <%= scope.lookupvar('rsyslog::client::rate_limit_burst') %>
+<% end -%>
+<% if scope.lookupvar('rsyslog::client::rate_limit_interval') -%>
+$SystemLogRateLimitInterval <%= scope.lookupvar('rsyslog::client::rate_limit_interval') %>
+<% end -%>
+
 <% if scope.lookupvar('rsyslog::client::ssl') -%>
 # Setup SSL connection.
 # CA/Cert


### PR DESCRIPTION
RHEL6/rsyslog 5 default rate limiting settings can cause messages to be dropped on high-volume clients.  This should allow one to override those defaults.