### PR TITLE
Notify the rsyslog service when changes occur to managed packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,18 +14,21 @@ class rsyslog::install {
   if $rsyslog::rsyslog_package_name != false {
     package { $rsyslog::rsyslog_package_name:
       ensure => $rsyslog::package_status,
+      notify => Class['rsyslog::service'],
     }
   }
 
   if $rsyslog::relp_package_name != false {
     package { $rsyslog::relp_package_name:
       ensure => $rsyslog::package_status
+      notify => Class['rsyslog::service'],
     }
   }
 
   if $rsyslog::gnutls_package_name != false {
     package { $rsyslog::gnutls_package_name:
       ensure => $rsyslog::package_status
+      notify => Class['rsyslog::service'],
     }
   }
 


### PR DESCRIPTION
Since the default value for the package ensure value is is "latest" this change would ensure rsyslog is restarted when the packages are updated by Puppet.