### PR TITLE
Support drop option for remote servers

### DIFF
--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -79,8 +79,14 @@ $ActionSendStreamDriverAuthMode anon
 <% format = '' -%>
 <% format_type = 'the default' -%>
 <% end -%>
+<% if server['thendrop'] -%>
+<% dropaction = '& ~' -%>
+<% else -%>
+<% dropaction = '' -%>
+<% end -%>
 # Sending logs that match <%= pattern %> to <%= host %> via <%= protocol_type %> on <%= port %> using <%=format_type %> format.
 <%= pattern %> <%= protocol %><%= host %>:<%= port %><%= format %>
+<%= dropaction %>
 <% end -%>
 <% elsif scope.lookupvar('rsyslog::client::log_remote') -%>
 


### PR DESCRIPTION
I needed a way to create rules to send content to specific remote servers / ports and then stop processing that content any further. This patch updates the client template to support a 'thendrop' key in the remote server hash passed to rsyslog::client as remote_servers. If 'thendrop' is set to true in the server definition, client.conf will include a "& ~" after the definition to instruct rsyslog to stop processing the message. 