### PR TITLE
Replaced version comparision conditionals with versioncmp function to

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,7 +79,7 @@ class rsyslog::params {
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
       }
-      elsif $::operatingsystemmajrelease == 5 {
+      elsif versioncmp($::operatingsystemmajrelease, '5') == 0 {
         $rsyslog_package_name   = 'rsyslog'
         $mysql_package_name     = 'rsyslog-mysql'
         $pgsql_package_name     = 'rsyslog-pgsql'
@@ -92,7 +92,7 @@ class rsyslog::params {
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
       }
-      elsif $::operatingsystemmajrelease == 6 {
+      elsif versioncmp($::operatingsystemmajrelease, '6') == 0 {
         $rsyslog_package_name   = 'rsyslog'
         $mysql_package_name     = 'rsyslog-mysql'
         $pgsql_package_name     = 'rsyslog-pgsql'
@@ -105,7 +105,7 @@ class rsyslog::params {
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
       }
-      elsif $::operatingsystemmajrelease >= 7 {
+      elsif versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $rsyslog_package_name   = 'rsyslog'
         $mysql_package_name     = 'rsyslog-mysql'
         $pgsql_package_name     = 'rsyslog-pgsql'

--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -12,9 +12,9 @@ describe 'rsyslog::client', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 
@@ -70,9 +70,9 @@ describe 'rsyslog::client', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 
@@ -128,9 +128,9 @@ describe 'rsyslog::client', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 

--- a/spec/classes/rsyslog_database_spec.rb
+++ b/spec/classes/rsyslog_database_spec.rb
@@ -12,9 +12,9 @@ describe 'rsyslog::database', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 
@@ -164,9 +164,9 @@ describe 'rsyslog::database', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 

--- a/spec/classes/rsyslog_server_spec.rb
+++ b/spec/classes/rsyslog_server_spec.rb
@@ -13,9 +13,9 @@ describe 'rsyslog::server', :type => :class do
       context "osfamily = #{osfamily}" do
         let :facts do
           default_facts.merge!({
-            :osfamily               => osfamily,
-            :operatingsystem        => osfamily,
-            :operatingsystemmajrelease => 6,
+            :osfamily                  => osfamily,
+            :operatingsystem           => osfamily,
+            :operatingsystemmajrelease => '6',
           })
         end
 
@@ -102,9 +102,9 @@ describe 'rsyslog::server', :type => :class do
       context "osfamily = #{osfamily}" do
         let :facts do
           default_facts.merge!({
-            :osfamily               => osfamily,
-            :operatingsystem        => osfamily,
-            :operatingsystemmajrelease => 6,
+            :osfamily                  => osfamily,
+            :operatingsystem           => osfamily,
+            :operatingsystemmajrelease => '6',
           })
         end
 

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -12,9 +12,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -68,9 +68,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -121,9 +121,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -174,9 +174,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -232,9 +232,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -288,9 +288,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -341,9 +341,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -394,9 +394,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
   
@@ -452,9 +452,9 @@ describe 'rsyslog', :type => :class do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 

--- a/spec/defines/rsyslog_imfile_spec.rb
+++ b/spec/defines/rsyslog_imfile_spec.rb
@@ -12,9 +12,9 @@ describe 'rsyslog::imfile', :type => :define do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 
@@ -94,9 +94,9 @@ describe 'rsyslog::imfile', :type => :define do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'RedHat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'RedHat',
+          :operatingsystemmajrelease => '6',
         })
       end
 

--- a/spec/defines/rsyslog_snippet_spec.rb
+++ b/spec/defines/rsyslog_snippet_spec.rb
@@ -12,9 +12,9 @@ describe 'rsyslog::snippet', :type => :define do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'Redhat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'Redhat',
+          :operatingsystemmajrelease => '6',
         })
       end
 
@@ -88,9 +88,9 @@ describe 'rsyslog::snippet', :type => :define do
     context "osfamily = RedHat" do
       let :facts do
         default_facts.merge!({
-          :osfamily               => 'RedHat',
-          :operatingsystem        => 'Redhat',
-          :operatingsystemmajrelease => 6,
+          :osfamily                  => 'RedHat',
+          :operatingsystem           => 'Redhat',
+          :operatingsystemmajrelease => '6',
         })
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ RSpec.configure do |c|
   end
   c.include PuppetlabsSpec::Files
 
+  if ENV['PARSER'] == 'future'
+    c.parser = 'future'
+  end
+
   c.before :each do
     # Ensure that we don't accidentally cache facts and environment
     # between test cases.


### PR DESCRIPTION
work with future parser. This includes updating tests to set version
facts to strings which is what facter returns.
Fixes issue #136.