### PR TITLE
Add :operatingsystem fact for specs failing on puppet > 3.4

### DIFF
--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -31,6 +31,7 @@ describe 'rsyslog::client', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -47,6 +48,7 @@ describe 'rsyslog::client', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 
@@ -89,6 +91,7 @@ describe 'rsyslog::client', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -105,6 +108,7 @@ describe 'rsyslog::client', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 

--- a/spec/classes/rsyslog_database_spec.rb
+++ b/spec/classes/rsyslog_database_spec.rb
@@ -63,6 +63,7 @@ describe 'rsyslog::database', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -111,6 +112,7 @@ describe 'rsyslog::database', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 
@@ -215,6 +217,7 @@ describe 'rsyslog::database', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -263,6 +266,7 @@ describe 'rsyslog::database', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 

--- a/spec/classes/rsyslog_server_spec.rb
+++ b/spec/classes/rsyslog_server_spec.rb
@@ -56,6 +56,7 @@ describe 'rsyslog::server', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 
@@ -145,6 +146,7 @@ describe 'rsyslog::server', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -33,6 +33,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -51,6 +52,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -88,6 +90,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -105,6 +108,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -141,6 +145,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -158,6 +163,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -193,6 +199,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -209,6 +216,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -253,6 +261,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -271,6 +280,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -308,6 +318,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -325,6 +336,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -361,6 +373,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -378,6 +391,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   
@@ -413,6 +427,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
   
@@ -429,6 +444,7 @@ describe 'rsyslog', :type => :class do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
   

--- a/spec/defines/rsyslog_imfile_spec.rb
+++ b/spec/defines/rsyslog_imfile_spec.rb
@@ -39,6 +39,7 @@ describe 'rsyslog::imfile', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -63,6 +64,7 @@ describe 'rsyslog::imfile', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 
@@ -121,6 +123,7 @@ describe 'rsyslog::imfile', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -145,6 +148,7 @@ describe 'rsyslog::imfile', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 

--- a/spec/defines/rsyslog_snippet_spec.rb
+++ b/spec/defines/rsyslog_snippet_spec.rb
@@ -37,6 +37,7 @@ describe 'rsyslog::snippet', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -59,6 +60,7 @@ describe 'rsyslog::snippet', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 
@@ -113,6 +115,7 @@ describe 'rsyslog::snippet', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'Debian',
+          :operatingsystem => 'Debian',
         })
       end
 
@@ -135,6 +138,7 @@ describe 'rsyslog::snippet', :type => :define do
       let :facts do
         default_facts.merge!({
           :osfamily        => 'freebsd',
+          :operatingsystem => 'freebsd',
         })
       end
 


### PR DESCRIPTION
Adding these missing `:operatingsystem` facts should get the build passing on all relevant versions.

I tested against `PUPPET_GEM_VERSION` `~> 3.4.0`, `~> 3.5.0`, and `~> 3.7.0`.