### PR TITLE
Features: Authentication Mode & LocalHostName Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# puppet-rsyslog [![Build Status](https://secure.travis-ci.org/saz/puppet-rsyslog.png)](https://travis-ci.org/saz/puppet-rsyslog)
+# saz/puppet-rsyslog [![Build Status](https://secure.travis-ci.org/saz/puppet-rsyslog.png)](https://travis-ci.org/saz/puppet-rsyslog)
 
 Manage rsyslog client and server via Puppet
 
@@ -148,7 +148,8 @@ The following lists all the class parameters this module accepts.
     -------------------------------------------------------------------
     enable_tcp                          true,false          Enable TCP listener. Defaults to true.
     enable_udp                          true,false          Enable UDP listener. Defaults to true.
-    address                             STRING              The IP address to bind to. Applies to UDP listener only. Defaults to '*'.
+    address                             STRING              The IP address to bind to. Applies to UDP listener only. Defaults to '*'.
+
     enable_relp                         true,false          Enable RELP listener. Defaults to true.
     enable_onefile                      true,false          Only one logfile per remote host. Defaults to false.
     server_dir                          STRING              Folder where logs will be stored on the server. Defaults to '/srv/log/'

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -44,6 +44,8 @@ class rsyslog::client (
   $port                      = '514',
   $remote_servers            = false,
   $ssl_ca                    = undef,
+  $auth_mode                 = undef,
+  $permitted_peer            = undef,
   $log_templates             = false,
   $actionfiletemplate        = false,
   $high_precision_timestamps = false,
@@ -69,5 +71,7 @@ class rsyslog::client (
   if $rsyslog::ssl and $remote_type != 'tcp' {
     fail('You need to enable tcp in order to use SSL.')
   }
+
+  # include testing for $auth_mode and $permitted_peer
 
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -72,6 +72,12 @@ class rsyslog::client (
     fail('You need to enable tcp in order to use SSL.')
   }
 
-  # include testing for $auth_mode and $permitted_peer
+  if $auth_mode and $rsyslog::ssl == false {
+    fail('You need to enable SSL in order to use $auth_mode.')
+  }
+
+  if $permitted_peer and $auth_mode == undef {
+    fail('$auth_mode must be defined in order to use $permitted_peer.')
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class rsyslog (
   $rsyslog_default_file   = $rsyslog::params::default_config_file,
   $run_user               = $rsyslog::params::run_user,
   $run_group              = $rsyslog::params::run_group,
+  $LocalHostName          = undef,
   $log_user               = $rsyslog::params::log_user,
   $log_group              = $rsyslog::params::log_group,
   $log_style              = $rsyslog::params::log_style,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class rsyslog (
   $rsyslog_default_file   = $rsyslog::params::default_config_file,
   $run_user               = $rsyslog::params::run_user,
   $run_group              = $rsyslog::params::run_group,
-  $LocalHostName          = undef,
+  $local_hostname         = undef,
   $log_user               = $rsyslog::params::log_user,
   $log_group              = $rsyslog::params::log_group,
   $log_style              = $rsyslog::params::log_style,

--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -42,6 +42,79 @@ describe 'rsyslog::client', :type => :class do
           should contain_file('/etc/rsyslog.d/client.conf')
         end
       end
+
+      context "auth_mode (osfamily = Debian)" do
+
+        let(:title) { 'rsyslog-client-auth_mode' }
+
+        context "without SSL" do
+          let(:params) { { :auth_mode => 'x509/name' } }
+          it 'should fail' do
+            expect { should contain_class('rsyslog::client') }
+              .to raise_error(Puppet::Error, /You need to enable SSL in order to use \$auth_mode./)
+          end
+        end
+
+        context "with SSL" do
+          let :pre_condition do
+            "class { 'rsyslog': ssl => true }"
+          end
+
+          ssl_params = { :ssl_ca => '/tmp/cert.pem' }
+
+          context "with default auth_mode" do
+            let(:params) { ssl_params }
+
+            it 'should compile' do
+              should contain_file('/etc/rsyslog.d/client.conf')
+                .with_content(/\$ActionSendStreamDriverAuthMode anon/)
+                .without_content(/\$ActionSendStreamDriverPermittedPeer/)
+            end
+          end
+
+          context "without permitted peer" do
+            let(:params) do
+              ssl_params.merge({
+                :auth_mode => 'x509/name',
+              })
+            end
+
+            it 'should contain ActionSendStreamDriverAuthMode' do
+              should contain_file('/etc/rsyslog.d/client.conf')
+                .with_content(/\$ActionSendStreamDriverAuthMode x509\/name/)
+                .without_content(/\$ActionSendStreamDriverPermittedPeer/)
+            end
+          end
+
+          context "permitted peer with anon auth_mode" do
+            let(:params) do
+              ssl_params.merge({
+                :permitted_peer => 'logs.example.com'
+              })
+            end
+
+            it 'should fail' do
+              expect { should contain_class('rsyslog::client') }
+                .to raise_error(Puppet::Error, /\$auth_mode must be defined in order to use \$permitted_peer./)
+            end
+          end
+
+          context "with permitted peer" do
+            let(:params) do
+              ssl_params.merge({
+                :auth_mode      => 'x509/name',
+                :permitted_peer => 'logs.example.com'
+              })
+            end
+
+            it 'should contain ActionSendStreamDriverPermittedPeer' do
+              should contain_file('/etc/rsyslog.d/client.conf')
+                .with_content(/\$ActionSendStreamDriverAuthMode x509\/name/)
+                .with_content(/\$ActionSendStreamDriverPermittedPeer logs.example.com/) 
+            end
+          end
+        end
+      end
     end
 
     context "osfamily = FreeBSD" do

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -46,6 +46,26 @@ describe 'rsyslog', :type => :class do
           should contain_class('rsyslog::service')
         end
       end
+
+      context "local hostname (osfamily = Debian)" do
+        let(:title) { 'rsyslog-local-hostname' }
+
+        context "with defaults" do
+          it 'is not set' do
+            should contain_file('/etc/rsyslog.conf')
+              .without_content(/\$LocalHostName/)
+          end
+        end
+
+        context "when set" do
+          let(:params) { { :local_hostname => 'example.dev' } }
+
+          it 'should compile' do
+            should contain_file('/etc/rsyslog.conf')
+              .with_content(/\$LocalHostName example.dev/)
+          end
+        end
+      end
     end
   
     context "osfamily = FreeBSD" do

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -53,13 +53,13 @@ $DefaultNetstreamDriverCAFile <%= scope.lookupvar('rsyslog::client::ssl_ca') %>
 # Connection settings.
 $DefaultNetstreamDriver gtls
 $ActionSendstreamDriverMode 1
-<% if scope.lookupvar('rsyslog::client::auth_mode') -%>
-$ActionSendStreamDriverAuthMode <%= scope.lookupvar('rsyslog::client::auth_mode') %>
+<% if @auth_mode -%>
+$ActionSendStreamDriverAuthMode <%= @auth_mode %>
+<% if @permitted_peer -%>
+$ActionSendStreamDriverPermittedPeer <%= @permitted_peer %>
+<% end -%>
 <% else -%>
 $ActionSendStreamDriverAuthMode anon
-<% end -%>
-<% if scope.lookupvar('rsyslog::client::auth_mode') == 'x509/name' -%>
-$ActionSendStreamDriverPermittedPeer <%= scope.lookupvar('rsyslog::client::permitted_peer') %>
 <% end -%>
 <% end -%>
 

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -48,13 +48,21 @@ $UDPServerRun 514
 <% if scope.lookupvar('rsyslog::client::ssl') -%>
 # Setup SSL connection.
 # CA/Cert
-$DefaultNetStreamDriverCAFile <%= scope.lookupvar('rsyslog::client::ssl_ca') %>
+$DefaultNetstreamDriverCAFile <%= scope.lookupvar('rsyslog::client::ssl_ca') %>
 
 # Connection settings.
 $DefaultNetstreamDriver gtls
-$ActionSendStreamDriverMode 1
+$ActionSendstreamDriverMode 1
+<% if scope.lookupvar('rsyslog::client::auth_mode') -%>
+$ActionSendStreamDriverAuthMode <%= scope.lookupvar('rsyslog::client::auth_mode') %>
+<% else -%>
 $ActionSendStreamDriverAuthMode anon
 <% end -%>
+<% if scope.lookupvar('rsyslog::client::auth_mode') == 'x509/name' -%>
+$ActionSendStreamDriverPermittedPeer <%= scope.lookupvar('rsyslog::client::permitted_peer') %>
+<% end -%>
+<% end -%>
+
 
 <% if scope.lookupvar('rsyslog::client::remote_type') == 'relp' -%>
 # Load RELP module.

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -2,6 +2,9 @@
 <% if scope.lookupvar('rsyslog::preserve_fqdn') -%>
 $PreserveFQDN on
 <% end -%>
+<% if scope.lookupvar('rsyslog::LocalHostName') -%>
+$LocalHostName <%= scope.lookupvar('rsyslog::LocalHostName') %>
+<% end -%>
 #################
 #### MODULES ####
 #################

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -2,8 +2,8 @@
 <% if scope.lookupvar('rsyslog::preserve_fqdn') -%>
 $PreserveFQDN on
 <% end -%>
-<% if scope.lookupvar('rsyslog::LocalHostName') -%>
-$LocalHostName <%= scope.lookupvar('rsyslog::LocalHostName') %>
+<% if @local_hostname -%>
+$LocalHostName <%= @local_hostname %>
 <% end -%>
 #################
 #### MODULES ####


### PR DESCRIPTION
Allows the user to specify an authentication mode, if that mode is `permitted peer` the user may then specify those peers.

LocalHostName is a rsyslog option that allows for reporting a hostname which is not the clients actual hostname.