### PR TITLE
fixed typo in for osfamily fact redhat vs RedHat in rsyslog_default.erb

### DIFF
--- a/templates/rsyslog_default.erb
+++ b/templates/rsyslog_default.erb
@@ -6,7 +6,7 @@ RSYSLOGD_OPTIONS="-c4"
 <% else -%>
 RSYSLOGD_OPTIONS=""
 <% end -%>
-<% if @osfamily == 'redhat' -%>
+<% if @osfamily == 'RedHat' -%>
 # CentOS, RedHat, Fedora
 SYSLOGD_OPTIONS="${RSYSLOGD_OPTIONS}"
 <% end -%>


### PR DESCRIPTION
I believe the correct osfamily value is RedHat, not redhat.  This fixes /var/log/messages entries such as:
```
2015-03-02T22:33:23.712485-05:00 www001 rsyslogd: [origin software="rsyslogd" swVersion="5.8.10" x-pid="378" x-info="http://www.rsyslog.com"] exiting on signal 15.
2015-03-02T22:33:23.827193-05:00 www001 kernel: imklog 5.8.10, log source = /proc/kmsg started.
2015-03-02T22:33:23.827280-05:00 www001 rsyslogd: [origin software="rsyslogd" swVersion="5.8.10" x-pid="879" x-info="http://www.rsyslog.com"] start
2015-03-02T22:33:23.823064-05:00 www001 rsyslogd: WARNING: rsyslogd is running in compatibility mode. Automatically generated config directives may interfer with your rsyslog.conf settings. We suggest upgrading your config and adding -c5 as the first rsyslogd option.
2015-03-02T22:33:23.826979-05:00 www001 rsyslogd: Warning: backward compatibility layer added to following directive to rsyslog.conf: ModLoad immark
2015-03-02T22:33:23.827071-05:00 www001 rsyslogd: Warning: backward compatibility layer added to following directive to rsyslog.conf: MarkMessagePeriod 1200
2015-03-02T22:33:23.827078-05:00 www001 rsyslogd: Warning: backward compatibility layer added to following directive to rsyslog.conf: ModLoad imuxsock
```