### PR TITLE
Adding ReadMode support to imfile template.

### DIFF
--- a/manifests/imfile.pp
+++ b/manifests/imfile.pp
@@ -7,6 +7,7 @@
 # [*file_name*]
 # [*file_tag*]
 # [*file_facility*]
+# [*file_readmode*]
 # [*ensure*]
 # [*polling_interval*]
 # [*file_severity*]
@@ -27,6 +28,7 @@ define rsyslog::imfile(
   $file_name,
   $file_tag,
   $file_facility,
+  $file_readmode = undef,
   $ensure = 'present',
   $polling_interval = 10,
   $file_severity = 'notice',
@@ -37,6 +39,15 @@ define rsyslog::imfile(
 
   include rsyslog
   $extra_modules = $rsyslog::extra_modules
+
+  # This mode should defined when having multiline messages.
+  $imfile_readmode = $file_readmode ? {
+    /^$/                 => undef, # Do not specify in configuration (current default behaviour)
+    /^(0|default|line)$/ => 0,     # Each line is a new message.
+    /^(1|paragraph)$/    => 1,     # There is a blank line between log messages.
+    /^(2|indented)$/     => 2,     # New log messages start at the beginning of a line. If a line starts with a space it is part of the log message before it.
+    default              => fail("Invalid file_readmode '${file_readmode}'. The value can range from 0-2 and determines the multiline detection method."),
+  }
 
   $file_ensure = $ensure ? {
     absent  => 'absent',

--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -8,6 +8,9 @@ $InputFileTag <%= @file_tag %>
 $InputFileStateFile state-<%= @name %>
 $InputFileSeverity <%= @file_severity %>
 $InputFileFacility <%= @file_facility %>
+<% if @imfile_readmode -%>
+$InputFileReadMode <%= @imfile_readmode %>
+<% end -%>
 $InputFilePollInterval <%= @polling_interval %>
 $InputFilePersistStateInterval <%= @persist_state_interval %>
 <% if @run_file_monitor == true -%>


### PR DESCRIPTION
Adding support for $InputFileReadMode.
Note: This legacy format doesn't allow the newer 'escaped LFs'.  
See http://www.rsyslog.com/doc/master/configuration/modules/imfile.html for more information