### PR TITLE
fixed two missing @ for variable access in client template

### DIFF
--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -113,10 +113,10 @@ $ModLoad omrelp
 <% elsif @log_remote -%>
 
 # Log to remote syslog server using <%= @remote_type %>
-<% if remote_type == 'tcp' -%>
+<% if @remote_type == 'tcp' -%>
 *.* @@<%= @server -%>:<%= @port -%>;<%= @remote_forward_format -%>
 <% else -%>
-<% if remote_type == 'relp' -%>
+<% if @remote_type == 'relp' -%>
 *.* :omrelp:<%= @server -%>:<%= @port -%>;<%= @remote_forward_format -%>
 <% else -%>
 *.* @<%= @server -%>:<%= @port -%>;<%= @remote_forward_format -%>


### PR DESCRIPTION
Simple addition of missing @ from remote_type in the client template. Looks like they were missed in the scope variable cleanup in f7355edcd25f0875c0819819dd44a5c081eedbc8 and cause the expected "Warning: Variable access via 'remote_type' is deprecated. Use '@remote_type' instead." deprecation warning.