### PR TITLE
performing string comparison in ruby template is case sensitive. 

### DIFF
--- a/templates/rsyslog_default.erb
+++ b/templates/rsyslog_default.erb
@@ -6,7 +6,7 @@ RSYSLOGD_OPTIONS="-c4"
 <% else -%>
 RSYSLOGD_OPTIONS=""
 <% end -%>
-<% if @osfamily == 'redhat' -%>
+<% if @osfamily.casecmp('redhat') -%>
 # CentOS, RedHat, Fedora
 SYSLOGD_OPTIONS="${RSYSLOGD_OPTIONS}"
 <% end -%>


### PR DESCRIPTION
switching to string casecmp function to make a case insensitive match.

The puppet fact @osfamily comes across as "RedHat" so I changed this to a case insensitive match.