### PR TITLE
Added OmitLocalLogging for EL7 config. Defaults to false everywhere else...

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ Both can be installed at the same time.
 
 The following lists all the class parameters this module accepts.
 
+    RSYSLOG CLASS PARAMETERS            VALUES              DESCRIPTION
+    -------------------------------------------------------------------
+    msg_reduction                       true,false          Reduce repeated messages. Defaults to false.
+    non_kernel_facility                 true,false          Permit non-kernel facility messages in the kernel log. Defaults to false.
+    omit_local_logging                  true,false          Turn off message reception via local log socket. Defaults to true only for RedHat 7+ and false elsewhere.
+    preserve_fqdn                       true,false          Use full name of host even if sender and receiver are in the same domain. Defaults to false.
+
     RSYSLOG::SERVER CLASS PARAMETERS    VALUES              DESCRIPTION
     -------------------------------------------------------------------
     enable_tcp                          true,false          Enable TCP listener. Defaults to true.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class rsyslog (
   $default_template       = $rsyslog::params::default_template,
   $msg_reduction          = $rsyslog::params::msg_reduction,
   $non_kernel_facility    = $rsyslog::params::non_kernel_facility,
+  $omit_local_logging     = $rsyslog::params::omit_local_logging,
 ) inherits rsyslog::params {
   class { 'rsyslog::install': }
   class { 'rsyslog::config': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class rsyslog (
   $default_template       = $rsyslog::params::default_template,
   $msg_reduction          = $rsyslog::params::msg_reduction,
   $non_kernel_facility    = $rsyslog::params::non_kernel_facility,
-  $omit_local_logging     = $rsyslog::params::omit_local_logging,
+  $omit_local_logging     = $rsyslog::params::omit_local_logging
 ) inherits rsyslog::params {
   class { 'rsyslog::install': }
   class { 'rsyslog::config': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,7 @@ class rsyslog::params {
       ]
       $service_hasrestart     = true
       $service_hasstatus      = true
+      $omit_local_logging     = false
     }
     redhat: {
       if $::operatingsystem == 'Amazon' {
@@ -76,6 +77,7 @@ class rsyslog::params {
           '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
+        $omit_local_logging     = false
       }
       elsif versioncmp($::operatingsystemmajrelease, '5') == 0 {
         $rsyslog_package_name   = 'rsyslog'
@@ -89,6 +91,7 @@ class rsyslog::params {
           '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
+        $omit_local_logging     = false
       }
       elsif versioncmp($::operatingsystemmajrelease, '6') == 0 {
         $rsyslog_package_name   = 'rsyslog'
@@ -102,6 +105,7 @@ class rsyslog::params {
           '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
+        $omit_local_logging     = false
       }
       elsif versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $rsyslog_package_name   = 'rsyslog'
@@ -116,6 +120,7 @@ class rsyslog::params {
           '#$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
+        $omit_local_logging     = true
       } else {
         $rsyslog_package_name   = 'rsyslog5'
         $mysql_package_name     = 'rsyslog5-mysql'
@@ -128,6 +133,7 @@ class rsyslog::params {
           '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
           '#$ModLoad immark  # provides --MARK-- message capability',
         ]
+        $omit_local_logging     = false
       }
       $package_status         = 'latest'
       $rsyslog_d              = '/etc/rsyslog.d/'
@@ -176,6 +182,7 @@ class rsyslog::params {
         '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
         '#$ModLoad immark  # provides --MARK-- message capability',
       ]
+      $omit_local_logging     = false
     }
     freebsd: {
       $rsyslog_package_name   = 'sysutils/rsyslog5'
@@ -208,6 +215,7 @@ class rsyslog::params {
       ]
       $service_hasrestart     = true
       $service_hasstatus      = true
+      $omit_local_logging     = false
     }
     default: {
       case $::operatingsystem {
@@ -242,6 +250,7 @@ class rsyslog::params {
           ]
           $service_hasrestart     = true
           $service_hasstatus      = true
+          $omit_local_logging     = false
         }
         default: {
           fail("The ${module_name} module is not supported on ${::osfamily}/${::operatingsystem}.")

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -52,6 +52,12 @@ $WorkDirectory <%= @spool_dir %>
 $Umask <%= @umask %>
 <% end -%>
 
+<% if @omit_local_logging -%>
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging on
+<% end -%>
+
 #
 # Include all config files in <%= @rsyslog_d %>
 #


### PR DESCRIPTION
I noticed double logging issues with the configs being generated on EL7 hosts and stumbled across #113. I can confirm that the stock rsyslog.conf shipped with EL7 includes:

```
# Turn off message reception via local log socket;
# local messages are retrieved through imjournal now.
$OmitLocalLogging on
```

... and that the presence of this prevents duplicate logging (both to /var/log/messages and remote syslog servers).

This PR adds an $omit_local_logging parameter to add this block to the rsyslog.conf.erb template for EL7. While it's arguably better to have a full on/off knob for this I kept this PR similar to the $msg_reduction and $non_kernel_facility knobs in that the block is only added when true.

Out of the supported operating systems I believe OmitLocalLogging is only set on EL7 at the moment. Certainly not a default in EL5, EL6, Amazon Linux AMI 2014.09, or Ubuntu LTS 14.04.1.
