### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,7 +84,7 @@ class rsyslog::params {
         $mysql_package_name     = 'rsyslog-mysql'
         $pgsql_package_name     = 'rsyslog-pgsql'
         $gnutls_package_name    = 'rsyslog-gnutls'
-        $relp_package_name      = 'rsyslog-relp'
+        $relp_package_name      = false
         $default_config_file    = 'rsyslog_default'
         $modules                = [
           '$ModLoad imuxsock # provides support for local system logging',


### PR DESCRIPTION
Update params.pp to remove reference to rsyslog-relp which is not present on CentOS5 or RHEL5 systems.