### PR TITLE
Added SQL format template to separate Syslogtag and ProcessID fields

### DIFF
--- a/templates/database.conf.erb
+++ b/templates/database.conf.erb
@@ -2,5 +2,8 @@
 
 ## Configuration file for rsyslog-<%= @backend %>
 
+# rsyslog template used to correctly separate Syslogtag and ProcessID fields for log entries
+$template sqlFormat,"INSERT INTO SystemEvents (Message, Facility, FromHost, Priority, DeviceReportedTime, ReceivedAt, InfoUnitID, SysLogTag, ProcessID) values ('%msg%',%syslogfacility%,'%HOSTNAME%',%syslogpriority%,'%timereported:::date-mysql%', '%timegenerated:::date-mysql%',%iut%,'%programname%','%procid:R,ERE,0,ZERO:[0-9]+--end%')",SQL
+
 $ModLoad <%= @db_module %>
-*.* :<%= @db_module -%>:<%= @server -%>,<%= @database -%>,<%= @username -%>,<%= @password %>
+*.* :<%= @db_module -%>:<%= @server -%>,<%= @database -%>,<%= @username -%>,<%= @password %>;sqlFormat


### PR DESCRIPTION
Added an rsyslog template for sql formatting, which properly separates the Syslogtag and ProcessID into their respective fields when inserting into an SQL database.

When using the Adiscon Log Analyzer, this not only allows proper filtering on the Syslogtag field, but also corrects the statistics graph generated from that field. This also facilitates searching and filtering by ProcessID field.

Before:
![before](https://cloud.githubusercontent.com/assets/1920234/12029702/021fa43e-adb7-11e5-9055-5c73260d44a1.png)

After:
![after](https://cloud.githubusercontent.com/assets/1920234/12029703/0899e5fe-adb7-11e5-87f1-fdd3cbf630b2.png)
