### PR TITLE
set rsyslog_version fact to be empty string by default

### DIFF
--- a/lib/facter/rsyslog_version.rb
+++ b/lib/facter/rsyslog_version.rb
@@ -13,7 +13,7 @@ Facter.add(:rsyslog_version) do
             if version =~ /.*[install|hold] ok installed;([^;]+);.*/
                 $1
             else
-                nil
+                ''
             end
         when "RedHat", "Suse"
             command='rpm -qa --qf "%{VERSION}" "rsyslog"'
@@ -21,7 +21,7 @@ Facter.add(:rsyslog_version) do
             if version =~ /^(.+)$/
                 $1
             else
-                nil
+                ''
             end
         when "FreeBSD"
           command='pkg query %v rsyslog'
@@ -29,10 +29,10 @@ Facter.add(:rsyslog_version) do
           if version =~ /^(.+)$/
             $1
           else
-            nil
+            ''
           end
         else
-            nil
+            ''
         end
     end
 end


### PR DESCRIPTION
causes some issues if rsyslog is not already installed, issue https://github.com/saz/puppet-rsyslog/issues/165 has some more details