### PR TITLE
add additional check against @rsyslog_version in case rsyslog is not installed

### DIFF
--- a/templates/server/_default-footer.conf.erb
+++ b/templates/server/_default-footer.conf.erb
@@ -14,7 +14,7 @@ $InputTCPServerRun <%= scope.lookupvar('rsyslog::server::port') %>
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::enable_relp') -%>
-<% if (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0) -%>
+<% if @rsyslog_version and (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0) -%>
 $InputRELPServerBindRuleset remote
 $InputRELPServerRun <%= scope.lookupvar('rsyslog::server::relp_port') %>
 <% end -%>

--- a/templates/server/_default-header.conf.erb
+++ b/templates/server/_default-header.conf.erb
@@ -9,7 +9,7 @@ $ModLoad imtcp
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::enable_relp') -%>
-<% if (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0) -%>
+<% if @rsyslog_version and (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0) -%>
 # Load RELP module
 $ModLoad imrelp
 <% end -%>


### PR DESCRIPTION
In a couple erb templates, the versioncmp check against the rsyslog_verion fact causes some issues if rsyslog is not already installed due to the fact being set to nil, which won't work with versioncmp.

Issue https://github.com/saz/puppet-rsyslog/issues/165 has some more details.

This is fixed by adding an additional check against rsyslog_version in the two erb files where it was causing issues, so the condition will short circuit before attempting to run versioncmp on nil.

Thanks :)