### PR TITLE
Fix nil rsyslog version

### DIFF
--- a/spec/classes/rsyslog_server_spec.rb
+++ b/spec/classes/rsyslog_server_spec.rb
@@ -181,4 +181,96 @@ describe 'rsyslog::server', :type => :class do
 
     end
   end
+
+  context "Rsyslog version = nil" do
+    let(:default_facts) do
+      {
+        :rsyslog_version => nil
+      }
+    end
+
+    ['RedHat', 'Debian'].each do |osfamily|
+      context "osfamily = #{osfamily}" do
+        let :facts do
+          default_facts.merge!({
+            :osfamily                  => osfamily,
+            :operatingsystem           => osfamily,
+            :operatingsystemmajrelease => '6',
+          })
+        end
+
+        context "default usage (osfamily = #{osfamily})" do
+          let(:title) { 'rsyslog-server-basic' }
+        
+          it 'should compile' do
+            should contain_file('/etc/rsyslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/auth.log/)
+            should contain_file('/etc/rsyslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/messages/)
+          end
+        end
+
+        context "enable_onefile (osfamily = #{osfamily})" do
+          let(:title) { 'rsyslog-server-onefile' }
+          let(:params) { {'enable_onefile' => 'true'} }
+    
+          it 'should compile' do
+            should_not contain_file('/etc/rsyslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/auth.log/)
+            should contain_file('/etc/rsyslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/messages/)
+          end
+        end
+
+        context "hostname_template (osfamily = #{osfamily})" do
+          let(:title) { 'rsyslog-server-onefile' }
+          let(:params) { {'custom_config' => 'rsyslog/server-hostname.conf.erb'} }
+    
+          it 'should compile' do
+            should contain_file('/etc/rsyslog.d/server.conf').with_content(/%hostname%\/auth.log/)
+            should contain_file('/etc/rsyslog.d/server.conf').with_content(/%hostname%\/messages/)
+          end
+        end
+
+      end
+    end
+
+
+    context "osfamily = FreeBSD" do
+      let :facts do
+        default_facts.merge!({
+          :osfamily        => 'FreeBSD',
+          :operatingsystem => 'FreeBSD',
+        })
+      end
+
+      context "default usage (osfamily = FreeBSD)" do
+        let(:title) { 'rsyslog-server-basic' }
+
+        it 'should compile' do
+          should contain_file('/etc/syslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/auth.log/)
+          should contain_file('/etc/syslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/messages/)
+        end
+      end
+
+      context "enable_onefile (osfamily = FreeBSD)" do
+        let(:title) { 'rsyslog-server-onefile' }
+        let(:params) { {'enable_onefile' => 'true'} }
+ 
+        it 'should compile' do
+          should_not contain_file('/etc/syslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/auth.log/)
+          should contain_file('/etc/syslog.d/server.conf').with_content(/\(\[A-Za-z-\]\*\)--end%\/messages/)
+        end
+      end
+
+      context "hostname_template (osfamily = FreeBSD)" do
+        let(:title) { 'rsyslog-server-onefile' }
+        let(:params) { {'custom_config' => 'rsyslog/server-hostname.conf.erb'} }
+ 
+        it 'should compile' do
+          should contain_file('/etc/syslog.d/server.conf').with_content(/%hostname%\/auth.log/)
+          should contain_file('/etc/syslog.d/server.conf').with_content(/%hostname%\/messages/)
+        end
+      end
+
+    end
+  end
+
+
 end # describe 'rsyslog::server'

--- a/templates/server/_default-footer.conf.erb
+++ b/templates/server/_default-footer.conf.erb
@@ -14,7 +14,7 @@ $InputTCPServerRun <%= scope.lookupvar('rsyslog::server::port') %>
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::enable_relp') -%>
-<% if (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0) -%>
+<% if (@rsyslog_version and (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0)) -%>
 $InputRELPServerBindRuleset remote
 $InputRELPServerRun <%= scope.lookupvar('rsyslog::server::relp_port') %>
 <% end -%>

--- a/templates/server/_default-header.conf.erb
+++ b/templates/server/_default-header.conf.erb
@@ -9,7 +9,7 @@ $ModLoad imtcp
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::enable_relp') -%>
-<% if (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0) -%>
+<% if (@rsyslog_version and (scope.function_versioncmp([@rsyslog_version, '6.3.6']) >= 0)) -%>
 # Load RELP module
 $ModLoad imrelp
 <% end -%>


### PR DESCRIPTION
The facter/lib/rsyslog_version.rb addon function can set rsyslog_version fact to nil if the package is not installed.
In that case, the templates/server/{_default-footer.conf.erb,_default-header.conf.erb} templates, call cause an error on the "scope.function_versioncmp" call.
This Pull-Request fixes this case, and adds unit tests to cover this case in the future.