### PR TITLE
rsyslog::snippet: replace slashes with dashes in namevar

### DIFF
--- a/manifests/snippet.pp
+++ b/manifests/snippet.pp
@@ -30,7 +30,8 @@ define rsyslog::snippet(
     $file_mode_real = $file_mode
   }
 
-  file { "${rsyslog::rsyslog_d}${name}.conf":
+  $name_real = regsubst($name,'\/','-','G')
+  file { "${rsyslog::rsyslog_d}${name_real}.conf":
     ensure  => $ensure,
     owner   => 'root',
     group   => $rsyslog::run_group,

--- a/manifests/snippet.pp
+++ b/manifests/snippet.pp
@@ -30,7 +30,7 @@ define rsyslog::snippet(
     $file_mode_real = $file_mode
   }
 
-  $name_real = regsubst($name,'\/','-','G')
+  $name_real = regsubst($name,'[/ ]','-','G')
   file { "${rsyslog::rsyslog_d}${name_real}.conf":
     ensure  => $ensure,
     owner   => 'root',

--- a/spec/defines/rsyslog_snippet_spec.rb
+++ b/spec/defines/rsyslog_snippet_spec.rb
@@ -30,6 +30,11 @@ describe 'rsyslog::snippet', :type => :define do
         it 'should compile' do
           should contain_file('/etc/rsyslog.d/rsyslog-snippet-basic.conf').with_content("# This file is managed by Puppet, changes may be overwritten\nRandom Content\n")
         end
+
+        let(:title) { 'rsyslog/snippet/basic' }
+        it 'should compile' do
+          should contain_file('/etc/rsyslog.d/rsyslog-snippet-basic.conf').with_content("# This file is managed by Puppet, changes may be overwritten\nRandom Content\n")
+        end
       end
     end
 

--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -5,7 +5,7 @@ $ModLoad imfile
 
 $InputFileName <%= @file_name %>
 $InputFileTag <%= @file_tag %>
-$InputFileStateFile state-<%= @name %>
+$InputFileStateFile state-<%= @name.gsub(/\//,'-') %>
 $InputFileSeverity <%= @file_severity %>
 $InputFileFacility <%= @file_facility %>
 <% if @imfile_readmode -%>

--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -5,7 +5,7 @@ $ModLoad imfile
 
 $InputFileName <%= @file_name %>
 $InputFileTag <%= @file_tag %>
-$InputFileStateFile state-<%= @name.gsub(/\//,'-') %>
+$InputFileStateFile state-<%= @name.gsub(/[\/ ]//,'-') %>
 $InputFileSeverity <%= @file_severity %>
 $InputFileFacility <%= @file_facility %>
 <% if @imfile_readmode -%>

--- a/templates/imfile.erb
+++ b/templates/imfile.erb
@@ -5,7 +5,7 @@ $ModLoad imfile
 
 $InputFileName <%= @file_name %>
 $InputFileTag <%= @file_tag %>
-$InputFileStateFile state-<%= @name.gsub(/[\/ ]//,'-') %>
+$InputFileStateFile state-<%= @name.gsub(/[\/ ]/,'-') %>
 $InputFileSeverity <%= @file_severity %>
 $InputFileFacility <%= @file_facility %>
 <% if @imfile_readmode -%>


### PR DESCRIPTION
This PR enables the use of rsyslog::imfile {'/var/log/audit/audit.log': ... }