### PR TITLE
Fix Case in params to corrent os names

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -111,7 +111,7 @@ class rsyslog::client (
   }
 
   if $ssl_auth_mode != 'anon' and $rsyslog::ssl == false {
-    fail("You need to enable SSL in order to use ssl_auth_mode.")
+    fail('You need to enable SSL in order to use ssl_auth_mode.')
   }
 
   if $ssl_permitted_peer and $ssl_auth_mode != 'x509/name' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class rsyslog::params {
   $preserve_fqdn              = false
 
   case $::osfamily {
-    debian: {
+    'Debian': {
       case $::operatingsystem {
         'Debian': {
           $log_user  = 'root'
@@ -33,6 +33,8 @@ class rsyslog::params {
           $log_user  = 'syslog'
           $run_user  = 'syslog'
           $run_group = 'syslog'
+        }
+        default: {
         }
       }
       $rsyslog_package_name   = 'rsyslog'
@@ -64,7 +66,7 @@ class rsyslog::params {
       $service_hasstatus      = true
       $omit_local_logging     = false
     }
-    redhat: {
+    'RedHat': {
       if $::operatingsystem == 'Amazon' {
         $rsyslog_package_name   = 'rsyslog'
         $mysql_package_name     = 'rsyslog-mysql'
@@ -155,7 +157,7 @@ class rsyslog::params {
       $service_hasrestart     = true
       $service_hasstatus      = true
     }
-    suse: {
+    'Suse': {
       $rsyslog_package_name   = 'rsyslog'
       $relp_package_name      = false
       $mysql_package_name     = false
@@ -185,7 +187,7 @@ class rsyslog::params {
       ]
       $omit_local_logging     = false
     }
-    freebsd: {
+    'FreeBSD': {
       $rsyslog_package_name   = 'sysutils/rsyslog5'
       $relp_package_name      = 'sysutils/rsyslog5-relp'
       $mysql_package_name     = 'sysutils/rsyslog5-mysql'
@@ -220,7 +222,7 @@ class rsyslog::params {
     }
     default: {
       case $::operatingsystem {
-        gentoo: {
+        'Gentoo': {
           $rsyslog_package_name   = 'app-admin/rsyslog'
           $relp_package_name      = false
           $mysql_package_name     = 'rsyslog-mysql'

--- a/metadata.json
+++ b/metadata.json
@@ -53,9 +53,6 @@
     }
   ],
   "description": "Manage rsyslog client and server via Puppet",
-  "types": [
-  
-  ],
   "dependencies": [
   
   ]


### PR DESCRIPTION
Fix Case statement to use the correct OS name
Removed empty types from metadata.json as this seems deprecated when checking with metadata-json-lint