### PR TITLE
casecmp returns a value that is always true

### DIFF
--- a/templates/rsyslog_default.erb
+++ b/templates/rsyslog_default.erb
@@ -6,7 +6,7 @@ RSYSLOGD_OPTIONS="-c4"
 <% else -%>
 RSYSLOGD_OPTIONS=""
 <% end -%>
-<% if @osfamily.casecmp('redhat') -%>
+<% if @osfamily.casecmp('redhat') == 0 -%>
 # CentOS, RedHat, Fedora
 SYSLOGD_OPTIONS="${RSYSLOGD_OPTIONS}"
 <% end -%>


### PR DESCRIPTION
Without a comparison operator, last if is always evaluated to true, no matter what is the content of @osfamily. (A value is always evaluated to true in ruby).