### PR TITLE
set default snippet content to empty string

### DIFF
--- a/manifests/snippet.pp
+++ b/manifests/snippet.pp
@@ -5,8 +5,8 @@
 #
 # === Parameters
 #
-# [*content*] - The actual content to place in the file.
-# [*ensure*]  - How to enforce the file (default: present)
+# [*content*]   - The actual content to place in the file. (default: empty sting)
+# [*ensure*]    - How to enforce the file (default: present)
 # [*file_mode*] - The mode of the file snippet (default: $rsyslog::perm_file)
 #
 # === Variables
@@ -18,7 +18,7 @@
 #  }
 #
 define rsyslog::snippet(
-  $content,
+  $content    = '',
   $ensure     = 'present',
   $file_mode  = 'undef'
 ) {


### PR DESCRIPTION
having attribute as mandatory requires supply content even when ensure => absent
Also, even in case of 'present' , one might want to just override a config file supplied by an rpm, for example