### PR TITLE
Fix: casecmp returns 0 on successful string match

### DIFF
--- a/templates/rsyslog_default.erb
+++ b/templates/rsyslog_default.erb
@@ -6,7 +6,7 @@ RSYSLOGD_OPTIONS="-c4"
 <% else -%>
 RSYSLOGD_OPTIONS=""
 <% end -%>
-<% if @osfamily.casecmp('redhat') -%>
+<% if @osfamily.casecmp('redhat') == 0 -%>
 # CentOS, RedHat, Fedora
 SYSLOGD_OPTIONS="${RSYSLOGD_OPTIONS}"
 <% end -%>


### PR DESCRIPTION
Ruby casecmp method returns 0 on successful match which made this condition work contrary to the original intent.