### PR TITLE
added ability to run as a relay server and removed some trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Declare the following to configure the connection:
     enable_udp                => true,
     enable_relp               => true,
     enable_onefile            => false,
+    relay_server              => false,
     server_dir                => '/srv/log/',
     custom_config             => undef,
     port                      => '514',
@@ -188,6 +189,7 @@ The following lists all the class parameters this module accepts.
     enable_udp                          true,false          Enable UDP listener. Defaults to true.
     enable_relp                         true,false          Enable RELP listener. Defaults to true.
     enable_onefile                      true,false          Only one logfile per remote host. Defaults to false.
+    relay_server                        true,false          If the server should be able to relay the received logs to another server. The rsyslog::client must also be set up.
     server_dir                          STRING              Folder where logs will be stored on the server. Defaults to '/srv/log/'
     custom_config                       STRING              Specify your own template to use for server config. Defaults to undef. Example usage: custom_config => 'rsyslog/my_config.erb'
     port                                STRING/INTEGER      Port to listen on for messages via UDP and TCP. Defaults to 514

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -194,7 +194,7 @@ class rsyslog::params {
     freebsd: {
       $rsyslog_package_name   = 'sysutils/rsyslog8'
       $relp_package_name      = false
-      $mysql_package_name     = false 
+      $mysql_package_name     = false
       $pgsql_package_name     = false
       $gnutls_package_name    = false
       $package_status         = 'present'
@@ -229,7 +229,7 @@ class rsyslog::params {
         gentoo: {
           $rsyslog_package_name   = 'app-admin/rsyslog'
           $relp_package_name      = false
-          $mysql_package_name     = 'rsyslog-mysql' 
+          $mysql_package_name     = 'rsyslog-mysql'
           $pgsql_package_name     = 'rsyslog-pgsql'
           $gnutls_package_name    = false
           $package_status         = 'latest'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,6 +8,7 @@
 # [*enable_udp*]
 # [*enable_relp*]
 # [*enable_onefile*]
+# [*relay_server*]
 # [*server_dir*]
 # [*custom_config*]
 # [*port*]
@@ -40,6 +41,7 @@ class rsyslog::server (
   $enable_udp                = true,
   $enable_relp               = true,
   $enable_onefile            = false,
+  $relay_server              = false,
   $server_dir                = '/srv/log/',
   $custom_config             = undef,
   $content                   = undef,

--- a/templates/server-default.conf.erb
+++ b/templates/server-default.conf.erb
@@ -3,6 +3,7 @@
 <% # Common header across all templates -%>
 <%= scope.function_template(['rsyslog/server/_default-header.conf.erb']) %>
 
+<% if scope.lookupvar('rsyslog::server::relay_server') == false -%>
 # Log files are stored in directories matching the short hostname, excluding numbers
 # i.e. web01 web02 and web03 will all log to a the web directory
 <% if scope.lookupvar('rsyslog::server::enable_onefile') == false -%>
@@ -45,6 +46,7 @@ $Template dynAllMessages,"<%= scope.lookupvar('rsyslog::server::server_dir') -%>
 
 # Rules
 *.*                 -?dynAllMessages
+<% end -%>
 <% end -%>
 
 <% # Common footer across all templates -%>

--- a/templates/server-hostname.conf.erb
+++ b/templates/server-hostname.conf.erb
@@ -3,6 +3,7 @@
 <% # Common header across all templates -%>
 <%= scope.function_template(['rsyslog/server/_default-header.conf.erb']) %>
 
+<% if scope.lookupvar('rsyslog::server::relay_server') == false -%>
 # Log files are stored in directories matching the hostname
 <% if scope.lookupvar('rsyslog::server::enable_onefile') == false -%>
 
@@ -35,6 +36,7 @@ $Template dynAllMessages,"<%= scope.lookupvar('rsyslog::server::server_dir') -%>
 
 # Rules
 *.*                 -?dynAllMessages
+<% end -%>
 <% end -%>
 
 <% # Common footer across all templates -%>

--- a/templates/server/_default-header.conf.erb
+++ b/templates/server/_default-header.conf.erb
@@ -54,5 +54,7 @@ $InputTCPServerStreamDriverMode 1
 $InputTCPServerStreamDriverAuthMode anon
 <% end -%>
 
+<% if scope.lookupvar('rsyslog::server::relay_server') == false -%>
 # Switch to remote ruleset
 $RuleSet remote
+<% end -%>


### PR DESCRIPTION
This is based on https://github.com/saz/puppet-rsyslog/issues/103

Add an option to run rsyslog server as a relay. 