### PR TITLE
Escape single-quotes in string

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -120,7 +120,7 @@ class rsyslog::client (
   }
 
   if $ssl_permitted_peer and $ssl_auth_mode != 'x509/name' {
-    fail('You need to set auth_mode to 'x509/name' in order to use ssl_permitted_peers.')
+    fail('You need to set auth_mode to \'x509/name\' in order to use ssl_permitted_peers.')
   }
 
   if $imfiles {


### PR DESCRIPTION
Commit saz/puppet-rsyslog@5892566100 switched string in manifests/client.pp to single quotes. Escape the embedded single quotes.