### PR TITLE
update im_journal params for RHEL7 versus others

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,10 +22,18 @@ class rsyslog::params {
   $msg_reduction                       = false
   $non_kernel_facility                 = false
   $preserve_fqdn                       = false
-  $im_journal_ratelimit_interval       = '600'
-  $im_journal_ratelimit_burst          = '20000'
-  $im_journal_ignore_previous_messages = 'off'
   $im_journal_statefile                = false
+
+  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+    $im_journal_ratelimit_interval       = '600'
+    $im_journal_ratelimit_burst          = '20000'
+    $im_journal_ignore_previous_messages = 'off'
+  }
+  else {
+    $im_journal_ratelimit_interval       = undef
+    $im_journal_ratelimit_burst          = undef
+    $im_journal_ignore_previous_messages = undef
+  }
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
From the module load pattern, it appears that im_journal only is appropriate for RHEL 7 - added if statement to that effect.