### PR TITLE
Nobody but "freebsd" gets Emergency messages (and more)

### DIFF
--- a/templates/client/local.conf.erb
+++ b/templates/client/local.conf.erb
@@ -99,6 +99,7 @@ ftp.info                                        /var/log/xferlog
 cron.*                                          /var/log/cron
 !-devd
 *.=debug                                        /var/log/debug.log
+<% end -%>
 <% if @rsyslog_version and @rsyslog_version.split('.')[0].to_i >= 7 -%>
 *.emerg       :omusrmsg:*
 <% else -%>
@@ -110,7 +111,6 @@ uucp,news.crit                 -/var/log/spooler
 
 # Save boot messages also to boot.log
 local7.*                       -/var/log/boot.log
-<% end -%>
 <% end -%>
 
 <% if @log_local_custom -%>


### PR DESCRIPTION
When logging locally, Red Hat based (and non-freebsd) servers don't get emergency messages set in the /etc/rsyslog.d/client.conf file. The file ends with only:

Everybody gets emergency messages

There is no '.emerg' line. This is because directly after line #90 in local.conf.erb file, there's an statement that checks for $log_style == 'freebsd'. This IF check essentially prevents messages from 'emerg' all the way down to 'local7.' from being set up in all OSs except FreeBSD.

I then the <% end -%> on line 113 needs to be moved up before line 102. Doing this breaks out of the statement for freebsd.