### PR TITLE
Fix imjournal settings to not show up with blank values on non-RHEL7 systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -142,7 +142,7 @@ class rsyslog::params {
         $im_journal_ratelimit_interval       = '600'
         $im_journal_ratelimit_burst          = '20000'
         $im_journal_ignore_previous_messages = 'off'
-        $im_journal_statefile                = false
+        $im_journal_statefile                = 'imjournal.state'
       } else {
         $rsyslog_package_name                = 'rsyslog5'
         $mysql_package_name                  = 'rsyslog5-mysql'

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -68,16 +68,16 @@ $OmitLocalLogging on
 <% end -%>
 
 # Settings for imjournal (If supported)
-<% if scope.lookupvar('rsyslog::im_journal_statefile') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_statefile') -%>
 $imjournalStateFile <%=scope.lookupvar('rsyslog::im_journal_statefile') %>
 <% end -%>
-<% if scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') -%>
 $imjournalIgnorePreviousMessages <%=scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') %>
 <% end -%>
-<% if scope.lookupvar('rsyslog::im_journal_ratelimit_interval') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_ratelimit_interval') -%>
 $imjournalRatelimitInterval <%=scope.lookupvar('rsyslog::im_journal_ratelimit_interval') %>
 <% end -%>
-<% if scope.lookupvar('rsyslog::im_journal_ratelimit_burst') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_ratelimit_burst') -%>
 $imjournalRatelimitBurst <%=scope.lookupvar('rsyslog::im_journal_ratelimit_burst') %>
 <% end -%>
 


### PR DESCRIPTION
Set default value for imjournalStateFile on RHEL7 to match default set on fresh install.  Also fix template to not put empty imjournal values on non-RHEL7.