### PR TITLE
Fix conditionals in rsyslog.conf template to work with both Puppet 3 and 4.

### DIFF
--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -97,7 +97,7 @@ describe 'rsyslog', type: :class do
         let(:title) { 'rsyslog-basic' }
 
         it 'compiles' do
-          should contain_file('/etc/rsyslog.conf')
+          should contain_file('/etc/rsyslog.conf').without_content(%r{\$imjournalRatelimitBurst})
           should contain_file('/etc/rsyslog.d/')
         end
       end

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -68,16 +68,16 @@ $OmitLocalLogging on
 <% end -%>
 
 # Settings for imjournal (If supported)
-<% if scope.lookupvar('rsyslog::im_journal_statefile') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_statefile') and scope.lookupvar('rsyslog::im_journal_statefile') != :undef -%>
 $imjournalStateFile <%=scope.lookupvar('rsyslog::im_journal_statefile') %>
 <% end -%>
-<% if scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') and scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') != :undef -%>
 $imjournalIgnorePreviousMessages <%=scope.lookupvar('rsyslog::im_journal_ignore_previous_messages') %>
 <% end -%>
-<% if scope.lookupvar('rsyslog::im_journal_ratelimit_interval') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_ratelimit_interval') and scope.lookupvar('rsyslog::im_journal_ratelimit_interval') != :undef -%>
 $imjournalRatelimitInterval <%=scope.lookupvar('rsyslog::im_journal_ratelimit_interval') %>
 <% end -%>
-<% if scope.lookupvar('rsyslog::im_journal_ratelimit_burst') != :undef -%>
+<% if scope.lookupvar('rsyslog::im_journal_ratelimit_burst') and scope.lookupvar('rsyslog::im_journal_ratelimit_burst') != :undef -%>
 $imjournalRatelimitBurst <%=scope.lookupvar('rsyslog::im_journal_ratelimit_burst') %>
 <% end -%>
 


### PR DESCRIPTION
There are many ways to test for undef variables but I've chosen to keep to what is already in the module https://github.com/saz/puppet-rsyslog/blob/master/templates/client/config.conf.erb#L40