### PR TITLE
Use default for imjournalStateFile on EL7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -142,7 +142,7 @@ class rsyslog::params {
         $im_journal_ratelimit_interval       = '600'
         $im_journal_ratelimit_burst          = '20000'
         $im_journal_ignore_previous_messages = 'off'
-        $im_journal_statefile                = false
+        $im_journal_statefile                = 'imjournal.state'
       } else {
         $rsyslog_package_name                = 'rsyslog5'
         $mysql_package_name                  = 'rsyslog5-mysql'


### PR DESCRIPTION
This change more closely matches what's setup by default on fresh install of EL7