### PR TITLE
Adding additional SSL options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ or send some bitcoins to ```1Na3YFUmdxKxJLiuRXQYJU2kiNqA3KY2j9```
     server                    => 'log',
     port                      => '514',
     remote_servers            => false,
+    ssl                       => false,
     ssl_ca                    => undef,
     ssl_permitted_peer        => undef,
     ssl_auth_mode             => 'anon',
@@ -172,9 +173,12 @@ rsyslog::client::log_filters:
     relp_port                 => '20514',
     address                   => '*',
     high_precision_timestamps => false,
+    ssl                       => false,
     ssl_ca                    => undef,
     ssl_cert                  => undef,
     ssl_key                   => undef,
+    ssl_permitted_peer        => undef,
+    ssl_auth_mode             => 'anon',
     log_templates             => false,
     log_filters               => false,
     actionfiletemplate        => false,
@@ -211,9 +215,12 @@ The following lists all the class parameters this module accepts.
     relp_port                           STRING/INTEGER      Port to listen on for messages via RELP. Defaults to 20514
     address                             STRING              The IP address to bind to. Applies to UDP listener only. Defaults to '*'.
     high_precision_timestamps           true,false          Whether or not to use high precision timestamps. Defaults to false.
+    ssl                                 true,false          Enable SSL support. Defaults to false.
     ssl_ca                              STRING              Path to SSL CA certificate. Defaults to undef.
     ssl_cert                            STRING              Path to SSL certificate. Defaults to undef.
     ssl_key                             STRING              Path to SSL private key. Defaults to undef.
+    ssl_permitted_peer                  STRING              List of permitted peers. Defaults to undef.
+    ssl_auth_mode                       STRING              SSL auth mode. Defaults to anon.
     log_templates                       HASH                Provides a hash defining custom logging templates using the `$template` configuration parameter. Defaults to false.
     log_filters                         HASH                Provides a hash defining custom logging filters using the `if/then` configurations parameter. Defaults to false.
     actionfiletemplate                  STRING              If set this defines the `ActionFileDefaultTemplate` which sets the default logging format for remote and local logging. Defaults to false.
@@ -233,7 +240,10 @@ The following lists all the class parameters this module accepts.
     server                              STRING              Rsyslog server to log to. Will be used in the client configuration file. Only used, if remote_servers is false.
     port                                '514'               Remote server port. Only used if remote_servers is false.
     remote_servers                      Array of hashes     Array of hashes with remote servers. See documentation above. Defaults to false.
+    ssl                                 true,false          Enable SSL support. Defaults to false.
     ssl_ca                              STRING              SSL CA file location. Defaults to undef.
+    ssl_cert                            STRING              Path to SSL certificate. Defaults to undef.
+    ssl_key                             STRING              Path to SSL private key. Defaults to undef.
     ssl_permitted_peer                  STRING              List of permitted peers. Defaults to undef.
     ssl_auth_mode                       STRING              SSL auth mode. Defaults to anon.
     log_templates                       HASH                Provides a hash defining custom logging templates using the `$template` configuration parameter.

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -19,7 +19,10 @@
 # [*server*]
 # [*port*]
 # [*remote_servers*]
+# [*ssl*]
 # [*ssl_ca*]
+# [*ssl_cert*]
+# [*ssl_key*]
 # [*ssl_permitted_peer*]
 # [*ssl_auth_mode*]
 # [*log_templates*]
@@ -52,7 +55,10 @@ class rsyslog::client (
   $server                    = 'log',
   $port                      = '514',
   $remote_servers            = false,
+  $ssl                       = false,
   $ssl_ca                    = undef,
+  $ssl_cert                  = undef,
+  $ssl_key                   = undef,
   $ssl_permitted_peer        = undef,
   $ssl_auth_mode             = 'anon',
   $log_templates             = false,
@@ -111,20 +117,24 @@ class rsyslog::client (
     }
   }
 
-  if $rsyslog::ssl and $ssl_ca == undef {
+  if $ssl and $ssl_ca == undef {
     fail('You need to define $ssl_ca in order to use SSL.')
   }
 
-  if $rsyslog::ssl and $remote_type != 'tcp' {
+  if $ssl and $remote_type != 'tcp' {
     fail('You need to enable tcp in order to use SSL.')
   }
 
-  if $ssl_auth_mode != 'anon' and $rsyslog::ssl == false {
+  if $ssl_auth_mode != 'anon' and $ssl == false {
     fail('You need to enable SSL in order to use ssl_auth_mode.')
   }
 
   if $ssl_permitted_peer and $ssl_auth_mode != 'x509/name' {
     fail('You need to set auth_mode to \'x509/name\' in order to use ssl_permitted_peers.')
+  }
+
+  if $ssl and ($ssl_cert and ! $ssl_key) or (! $ssl_cert and $ssl_key) {
+    fail('If using client side certificates, you must define both the cert and the key.')
   }
 
   if $imfiles {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,6 @@ class rsyslog (
   $service_name                        = $rsyslog::params::service_name,
   $service_hasrestart                  = $rsyslog::params::service_hasrestart,
   $service_hasstatus                   = $rsyslog::params::service_hasstatus,
-  $ssl                                 = $rsyslog::params::ssl,
   $modules                             = $rsyslog::params::modules,
   $preserve_fqdn                       = $rsyslog::params::preserve_fqdn,
   $local_host_name                     = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,7 +54,6 @@ class rsyslog::params {
       $perm_dir                            = '0755'
       $spool_dir                           = '/var/spool/rsyslog'
       $service_name                        = 'rsyslog'
-      $ssl                                 = false
       $modules                             = [
         '$ModLoad imuxsock # provides support for local system logging',
         '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
@@ -173,7 +172,6 @@ class rsyslog::params {
       $perm_dir               = '0750'
       $spool_dir              = '/var/lib/rsyslog'
       $service_name           = 'rsyslog'
-      $ssl                    = false
       $service_hasrestart     = true
       $service_hasstatus      = true
     }
@@ -230,7 +228,6 @@ class rsyslog::params {
       $perm_dir                            = '0755'
       $spool_dir                           = '/var/spool/rsyslog'
       $service_name                        = 'rsyslogd'
-      $ssl                                 = false
       $modules                             = [
         '$ModLoad imuxsock # provides support for local system logging',
         '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
@@ -267,7 +264,6 @@ class rsyslog::params {
           $perm_dir                            = '0755'
           $spool_dir                           = '/var/spool/rsyslog'
           $service_name                        = 'rsyslog'
-          $ssl                                 = false
           $modules                             = [
             '$ModLoad imuxsock # provides support for local system logging',
             '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,6 +19,8 @@
 # [*ssl_ca*]
 # [*ssl_cert*]
 # [*ssl_key*]
+# [*ssl_permitted_peer*]
+# [*ssl_auth_mode*]
 # [*log_templates*]
 # [*log_filters*]
 # [*actionfiletemplate*]
@@ -51,9 +53,12 @@ class rsyslog::server (
   $relp_port                 = '20514',
   $address                   = '*',
   $high_precision_timestamps = false,
+  $ssl                       = false,
   $ssl_ca                    = undef,
   $ssl_cert                  = undef,
   $ssl_key                   = undef,
+  $ssl_permitted_peer        = undef,
+  $ssl_auth_mode             = 'anon',
   $log_templates             = false,
   $log_filters               = false,
   $actionfiletemplate        = false,
@@ -88,7 +93,15 @@ class rsyslog::server (
     content => $real_content,
   }
 
-  if $rsyslog::ssl and (!$enable_tcp or $ssl_ca == undef or $ssl_cert == undef or $ssl_key == undef) {
+  if $ssl and (!$enable_tcp or $ssl_ca == undef or $ssl_cert == undef or $ssl_key == undef) {
     fail('You need to define all the ssl options and enable tcp in order to use SSL.')
+  }
+
+  if $ssl_auth_mode != 'anon' and $ssl == false {
+    fail('You need to enable SSL in order to use ssl_auth_mode.')
+  }
+
+  if $ssl_permitted_peer and $ssl_auth_mode != 'x509/name' {
+    fail('You need to set auth_mode to \'x509/name\' in order to use ssl_permitted_peers.')
   }
 }

--- a/templates/client/config.conf.erb
+++ b/templates/client/config.conf.erb
@@ -51,10 +51,14 @@ $UDPServerAddress 127.0.0.1
 $UDPServerRun 514
 <% end %>
 
-<% if scope.lookupvar('rsyslog::ssl') -%>
+<% if scope.lookupvar('rsyslog::client::ssl') -%>
 # Setup SSL connection.
 # CA/Cert
 $DefaultNetStreamDriverCAFile <%= scope.lookupvar('rsyslog::client::ssl_ca') %>
+<% if scope.lookupvar('rsyslog::client::ssl_cert') -%>
+$DefaultNetstreamDriverCertFile <%= scope.lookupvar('rsyslog::client::ssl_cert') %>
+$DefaultNetstreamDriverKeyFile <%= scope.lookupvar('rsyslog::client::ssl_key') %>
+<% end -%>
 
 # Connection settings.
 $DefaultNetstreamDriver gtls

--- a/templates/server/_default-header.conf.erb
+++ b/templates/server/_default-header.conf.erb
@@ -48,7 +48,7 @@ $ActionFileDefaultTemplate RSYSLOG_FileFormat
 <% end -%>
 <% end -%>
 
-<% if scope.lookupvar('rsyslog::ssl') -%>
+<% if scope.lookupvar('rsyslog::server::ssl') -%>
 # Server side SSL.
 $DefaultNetstreamDriver gtls
 
@@ -58,7 +58,10 @@ $DefaultNetstreamDriverCertFile <%= scope.lookupvar('rsyslog::server::ssl_cert')
 $DefaultNetstreamDriverKeyFile <%= scope.lookupvar('rsyslog::server::ssl_key') %>
 
 $InputTCPServerStreamDriverMode 1
-$InputTCPServerStreamDriverAuthMode anon
+$InputTCPServerStreamDriverAuthMode <%= scope.lookupvar('rsyslog::server::ssl_auth_mode') %>
+<% if @ssl_permitted_peer -%>
+$ActionSendStreamDriverPermittedPeer <%= scope.lookupvar('rsyslog::server::ssl_permitted_peer') %>
+<% end -%>
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::relay_server') == false -%>


### PR DESCRIPTION
Hi Saz, 

I have created these changes to enable a few additional SSL features. They are: 
- Allow the use of client-side SSL certificates 
- Allow a RSYSLOG relay to use SSL for the server part, but not for the client part, and vice-versa. I achieved this by moving the "ssl" parameter to the client and server classes, and removing it from init. 
- Added ssl_permitted_peer and ssl_auth_mode to the server class. 
- Added some additional tests

Cheers, 
Nick