### PR TITLE
On Redhat/Suse, use rsyslogd -v to determine the version

### DIFF
--- a/lib/facter/rsyslog_version.rb
+++ b/lib/facter/rsyslog_version.rb
@@ -14,9 +14,15 @@ Facter.add(:rsyslog_version) do
         Regexp.last_match(1)
       end
     when 'RedHat', 'Suse'
-      command = 'rpm -qa --qf "%{VERSION}" "rsyslog"'
-      version = Facter::Util::Resolution.exec(command)
-      Regexp.last_match(1) if version =~ %r{^(.+)$}
+      if File.exists? "/sbin/rsyslogd"
+        # Query rsyslogd binary for the version
+        Facter::Util::Resolution.exec("rsyslogd -v | head -n 1 | awk '{print $2}' | sed 's/,//g'")
+      else
+        # Fall back to rpm to determine version
+        command = 'rpm -qa --qf "%{VERSION}" "rsyslog"'
+        version = Facter::Util::Resolution.exec(command)
+        Regexp.last_match(1) if version =~ %r{^(.+)$}
+      end
     when 'FreeBSD'
       command = 'pkg query %v rsyslog8'
       version = Facter::Util::Resolution.exec(command)


### PR DESCRIPTION
This method is much faster than the 'rpm -qa' dance that needs to run on every facter run. This fixes #204.

## Some benchmarks

Old version, `rpm -qa | grep ... `, 3 different runs:
```
3.142s
3.972s
2.740s
```

New version with `rsyslogd -v`, 3 different runs:
```
1.811s
1.778s
1.575s
```