### PR TITLE
Fix containment issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Gathers log information from a file
 ```
 #### rsyslog.d conf files
 
-e.g. rsyslog.d/10-puppetagent.conf - moves puppet-agent entries to a file and excludes from /var/log/messages 
+e.g. rsyslog.d/10-puppetagent.conf - moves puppet-agent entries to a file and excludes from /var/log/messages
 ```
   rsyslog::snippet { '10-puppetagent':
     content => ":programname,contains,\"puppet-agent\" /var/log/puppetlabs/puppet/puppet-agent.log\n& ~",
@@ -300,3 +300,17 @@ with the main rsyslog package.
 
 Default package_status parameter for rsyslog class used to be 'latest'. However, it was
 against puppet best practices so it defaults to 'present' now.
+
+#### Relationships
+
+Be sure to make a relationship to the `rsyslog` class if you need something to happen before or after Puppet manages rsyslog. Even if you're just using `rsyslog::client` or `rsyslog::server`.
+
+For example, if you want to make sure the EPEL YUM repositories are managed by Puppet before trying to setup an rsyslog client, do the following:
+
+```puppet
+include epel                       # This is from the stahnma/epel Forge module
+include rsyslog::client
+
+Class['epel'] -> Class['rsyslog']  # Note this forms a relationship to rsyslog, not rsyslog::client
+```
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,12 +52,16 @@ class rsyslog (
   $im_journal_ratelimit_burst          = $rsyslog::params::im_journal_ratelimit_burst,
   $im_journal_ignore_previous_messages = $rsyslog::params::im_journal_ignore_previous_messages
 ) inherits rsyslog::params {
-  class { '::rsyslog::install': }
-  class { '::rsyslog::config': }
+
+  contain rsyslog::install
+  contain rsyslog::config
+  contain rsyslog::service
 
   if $extra_modules != [] {
-    class { '::rsyslog::modload': }
+    include rsyslog::modload
   }
 
-  class { '::rsyslog::service': }
+  Class['rsyslog::install'] -> Class['rsyslog::config'] ~> Class['rsyslog::service']
+
 }
+

--- a/metadata.json
+++ b/metadata.json
@@ -49,11 +49,11 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.4.0 < 5.0.0"
     }
   ],
   "description": "Manage rsyslog client and server via Puppet",
   "dependencies": [
-  
+
   ]
 }

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -22,8 +22,8 @@ describe 'rsyslog', type: :class do
 
         it 'compiles' do
           is_expected.to contain_class('rsyslog::install')
-          is_expected.to contain_class('rsyslog::config')
-          is_expected.to contain_class('rsyslog::service')
+          is_expected.to contain_class('rsyslog::config').that_requires('Class[rsyslog::install]')
+          is_expected.to contain_class('rsyslog::service').that_subscribes_to('Class[rsyslog::config]')
         end
       end
     end
@@ -41,8 +41,8 @@ describe 'rsyslog', type: :class do
 
         it 'compiles' do
           is_expected.to contain_class('rsyslog::install')
-          is_expected.to contain_class('rsyslog::config')
-          is_expected.to contain_class('rsyslog::service')
+          is_expected.to contain_class('rsyslog::config').that_requires('Class[rsyslog::install]')
+          is_expected.to contain_class('rsyslog::service').that_subscribes_to('Class[rsyslog::config]')
         end
       end
 
@@ -78,8 +78,8 @@ describe 'rsyslog', type: :class do
 
         it 'compiles' do
           is_expected.to contain_class('rsyslog::install')
-          is_expected.to contain_class('rsyslog::config')
-          is_expected.to contain_class('rsyslog::service')
+          is_expected.to contain_class('rsyslog::config').that_requires('Class[rsyslog::install]')
+          is_expected.to contain_class('rsyslog::service').that_subscribes_to('Class[rsyslog::config]')
         end
       end
     end
@@ -286,8 +286,8 @@ describe 'rsyslog', type: :class do
 
         it 'compiles' do
           is_expected.to contain_class('rsyslog::install')
-          is_expected.to contain_class('rsyslog::config')
-          is_expected.to contain_class('rsyslog::service')
+          is_expected.to contain_class('rsyslog::config').that_requires('Class[rsyslog::install]')
+          is_expected.to contain_class('rsyslog::service').that_subscribes_to('Class[rsyslog::config]')
         end
       end
     end
@@ -305,8 +305,8 @@ describe 'rsyslog', type: :class do
 
         it 'compiles' do
           is_expected.to contain_class('rsyslog::install')
-          is_expected.to contain_class('rsyslog::config')
-          is_expected.to contain_class('rsyslog::service')
+          is_expected.to contain_class('rsyslog::config').that_requires('Class[rsyslog::install]')
+          is_expected.to contain_class('rsyslog::service').that_subscribes_to('Class[rsyslog::config]')
         end
       end
     end
@@ -324,8 +324,8 @@ describe 'rsyslog', type: :class do
 
         it 'compiles' do
           is_expected.to contain_class('rsyslog::install')
-          is_expected.to contain_class('rsyslog::config')
-          is_expected.to contain_class('rsyslog::service')
+          is_expected.to contain_class('rsyslog::config').that_requires('Class[rsyslog::install]')
+          is_expected.to contain_class('rsyslog::service').that_subscribes_to('Class[rsyslog::config]')
         end
       end
     end


### PR DESCRIPTION
This resolves issue #259 

Prior to this, it was impossible to make a relationship to the 'rsyslog' class from another class and expect the install, config, and service classes to honor the relationship. The reason being that those classes were not contained.

<https://puppet.com/blog/class-containment-puppet>

This fixes that by using the `contain` function to properly contain the
install, config, and service classes within the rsyslog class.

<https://docs.puppet.com/puppet/4.9/lang_containment.html#the-contain-function>

This lets someone make the following relationship, for example when needing to make sure that the EPEL YUM repos are managed before installing rsyslog:

```puppet
include epel
include rsyslog::client

Class['epel'] -> Class['rsyslog']
```


Note that there are two ways to solve the containment problem, the first being to use the `contain` function which requires Puppet > v3.4.0. The second is to use the anchor pattern if you need to support older versions of Puppet; however, that then requires stdlib to get access to the `anchor` resource. I chose to use the contain function over the anchor resource because trying to support really old versions of Puppet is not something we should be doing.