### PR TITLE
Use rpm -q rather than rpm -qa in fact saves 1 second.

### DIFF
--- a/lib/facter/rsyslog_version.rb
+++ b/lib/facter/rsyslog_version.rb
@@ -19,7 +19,7 @@ Facter.add(:rsyslog_version) do
         Facter::Util::Resolution.exec("rsyslogd -v | head -n 1 | awk '{print $2}' | sed 's/,//g'")
       else
         # Fall back to rpm to determine version
-        command = 'rpm -qa --qf "%{VERSION}" "rsyslog"'
+        command = 'rpm -q --qf "%{VERSION}" "rsyslog"'
         version = Facter::Util::Resolution.exec(command)
         Regexp.last_match(1) if version =~ %r{^(.+)$}
       end

--- a/metadata.json
+++ b/metadata.json
@@ -44,10 +44,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 3.4.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }

--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -107,6 +107,7 @@ describe 'rsyslog::client', type: :class do
 
         context 'without SSL' do
           let(:params) { { ssl_auth_mode: 'x509/name' } }
+
           it 'fails' do
             expect { is_expected.to contain_class('rsyslog::client') }.to raise_error(Puppet::Error, %r{You need to enable SSL in order to use ssl_auth_mode.})
           end

--- a/spec/classes/rsyslog_server_spec.rb
+++ b/spec/classes/rsyslog_server_spec.rb
@@ -8,7 +8,7 @@ describe 'rsyslog::server', type: :class do
       }
     end
 
-    %w(RedHat Debian).each do |osfamily|
+    %w[RedHat Debian].each do |osfamily|
       context "osfamily = #{osfamily}" do
         let :facts do
           default_facts.merge!(
@@ -104,7 +104,7 @@ describe 'rsyslog::server', type: :class do
       }
     end
 
-    %w(RedHat Debian).each do |osfamily|
+    %w[RedHat Debian].each do |osfamily|
       context "osfamily = #{osfamily}" do
         let :facts do
           default_facts.merge!(
@@ -200,7 +200,7 @@ describe 'rsyslog::server', type: :class do
       }
     end
 
-    %w(RedHat Debian).each do |osfamily|
+    %w[RedHat Debian].each do |osfamily|
       context "osfamily = #{osfamily}" do
         let :facts do
           default_facts.merge!(


### PR DESCRIPTION
In addition to switching from rpm -qa to rpm -q the metadata.json needed fixeing to remove
the pe version of puppet. puppetforge no longer supports this apparently according to lint.