### PR TITLE
PrivDropToUser and PrivDropToGroup are only available on rsyslog 4.1.1 and newer

### DIFF
--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -64,8 +64,10 @@ $FileCreateMode <%= scope.lookupvar('rsyslog::perm_file') %>
 $DirOwner <%= scope.lookupvar('rsyslog::log_user') %>
 $DirGroup <%= scope.lookupvar('rsyslog::log_group') %>
 $DirCreateMode <%= scope.lookupvar('rsyslog::perm_dir') %>
+<% if Gem::Version.new(scope.lookupvar('::rsyslog_version')) >= Gem::Version.new('4.1.1') -%>
 $PrivDropToUser <%= scope.lookupvar('rsyslog::run_user') %>
 $PrivDropToGroup <%= scope.lookupvar('rsyslog::run_group') %>
+<% end -%>
 $WorkDirectory <%= scope.lookupvar('rsyslog::spool_dir') %>
 <% if scope.lookupvar('rsyslog::umask') -%>
 $Umask <%= scope.lookupvar('rsyslog::umask') %>

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -26,6 +26,7 @@ $KLogPermitNonKernelFacility on
 #
 $MaxMessageSize <%= scope.lookupvar('rsyslog::max_message_size') %>
 
+<% if Gem::Version.new(scope.lookupvar('::rsyslog_version')) >= Gem::Version.new('5.7.1') -%>
 #
 # Set rate limit for messages received.
 #
@@ -34,6 +35,7 @@ $SystemLogRateLimitInterval <%= scope.lookupvar('rsyslog::system_log_rate_limit_
 <%- end -%>
 <%- if scope.lookupvar('rsyslog::system_log_rate_limit_burst') -%>
 $SystemLogRateLimitBurst <%= scope.lookupvar('rsyslog::system_log_rate_limit_burst') %>
+<%- end -%>
 <%- end -%>
 
 <% if scope.lookupvar('rsyslog::default_template') and scope.lookupvar('rsyslog::default_template') != :undef and scope.lookupvar('rsyslog::default_template_customisation') and scope.lookupvar('rsyslog::default_template_customisation') != :undef -%>

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -28,11 +28,11 @@ $MaxMessageSize <%= scope.lookupvar('rsyslog::max_message_size') %>
 
 #
 # Set rate limit for messages received.
-# 
-<%- if @system_log_rate_limit_interval -%>
+#
+<%- if scope.lookupvar('rsyslog::system_log_rate_limit_interval') -%>
 $SystemLogRateLimitInterval <%= scope.lookupvar('rsyslog::system_log_rate_limit_interval') %>
 <%- end -%>
-<%- if @system_log_rate_limit_burst -%>
+<%- if scope.lookupvar('rsyslog::system_log_rate_limit_burst') -%>
 $SystemLogRateLimitBurst <%= scope.lookupvar('rsyslog::system_log_rate_limit_burst') %>
 <%- end -%>
 


### PR DESCRIPTION
Added a conditional statement to templates/rsyslog.conf.erb so that the resulting configuration works on RHEL5 hosts, where the rsyslog package is 3.x. 