### PR TITLE
Leave umask unset for redhat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -168,7 +168,7 @@ class rsyslog::params {
       $log_user               = 'root'
       $log_group              = 'root'
       $log_style              = 'redhat'
-      $umask                  = '0000'
+      $umask                  = false
       $perm_file              = '0600'
       $perm_dir               = '0750'
       $spool_dir              = '/var/lib/rsyslog'


### PR DESCRIPTION
Setting Rsyslog's umask to 0000 causes the /var/lib/rsyslog/imjournal.state file to be created with world writable permissions. This was fixable by setting the umask parameter, however, I don't think the umask should be set by default.