### PR TITLE
remove -a param from rpm command to improve performance of fact

### DIFF
--- a/lib/facter/rsyslog_version.rb
+++ b/lib/facter/rsyslog_version.rb
@@ -19,7 +19,7 @@ Facter.add(:rsyslog_version) do
         Facter::Util::Resolution.exec("rsyslogd -v | head -n 1 | awk '{print $2}' | sed 's/,//g'")
       else
         # Fall back to rpm to determine version
-        command = 'rpm -qa --qf "%{VERSION}" "rsyslog"'
+        command = 'rpm -q --qf "%{VERSION}" "rsyslog"'
         version = Facter::Util::Resolution.exec(command)
         Regexp.last_match(1) if version =~ %r{^(.+)$}
       end


### PR DESCRIPTION
Would like to submit this very small change to the fact code to improve the time it takes to run in the case where it has to fall back to the rpm database to get the version.