### PR TITLE
Fix UDPServerAddress order in server footer template

### DIFF
--- a/templates/server/_default-footer.conf.erb
+++ b/templates/server/_default-footer.conf.erb
@@ -6,8 +6,8 @@ $RuleSet RSYSLOG_DefaultRuleset
 <% if scope.lookupvar('rsyslog::server::remote_ruleset_udp') -%>
 $InputUDPServerBindRuleset remote
 <% end -%>
-$UDPServerRun <%= scope.lookupvar('rsyslog::server::port') %>
 $UDPServerAddress <%= scope.lookupvar('rsyslog::server::address') %>
+$UDPServerRun <%= scope.lookupvar('rsyslog::server::port') %>
 <% end -%>
 
 <% if scope.lookupvar('rsyslog::server::enable_tcp') -%>


### PR DESCRIPTION
To be effective, the option must precede the Run option.