### PR TITLE
Add usrmsg_users parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The following lists all the class parameters this module accepts.
     preserve_fqdn                       true,false          Use full name of host even if sender and receiver are in the same domain. Defaults to false.
     local_host_name                     STRING              Use a custom local host name, instead of clients actual host name. Defaults to undef.
     package_status                      STRING              Manages rsyslog package installation. Defaults to 'present'.
+    usrmsg_users                        Array               Array of user names that will receive messages when logged, Defaults to ['*'] (all users)
 
     RSYSLOG::SERVER CLASS PARAMETERS    VALUES              DESCRIPTION
     -------------------------------------------------------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,8 @@ class rsyslog (
   $im_journal_ratelimit_interval       = $rsyslog::params::im_journal_ratelimit_interval,
   $im_journal_statefile                = $rsyslog::params::im_journal_statefile,
   $im_journal_ratelimit_burst          = $rsyslog::params::im_journal_ratelimit_burst,
-  $im_journal_ignore_previous_messages = $rsyslog::params::im_journal_ignore_previous_messages
+  $im_journal_ignore_previous_messages = $rsyslog::params::im_journal_ignore_previous_messages,
+  $usrmsg_users                        = $rsyslog::params::usrmsg_users
 ) inherits rsyslog::params {
   class { '::rsyslog::install': }
   class { '::rsyslog::config': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class rsyslog::params {
   $msg_reduction                  = false
   $non_kernel_facility            = false
   $preserve_fqdn                  = false
+  $usrmsg_users                   = ['*']
 
   case $::osfamily {
     'Debian': {

--- a/templates/client/local.conf.erb
+++ b/templates/client/local.conf.erb
@@ -103,7 +103,7 @@ cron.*                                          /var/log/cron
 *.=debug                                        /var/log/debug.log
 <% end -%>
 <% if @rsyslog_version and @rsyslog_version.split('.')[0].to_i >= 7 -%>
-*.emerg       :omusrmsg:*
+*.emerg       :omusrmsg:<%= scope.lookupvar('rsyslog::usrmsg_users').join(',') %>
 <% else -%>
 *.emerg				*
 <% end -%>

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -100,7 +100,7 @@ $IncludeConfig <%= scope.lookupvar('rsyslog::rsyslog_d') -%>*.conf
 # Emergencies are sent to everybody logged in.
 #
 <% if @rsyslog_version and @rsyslog_version.split('.')[0].to_i >= 7 -%>
-*.emerg	:omusrmsg:*
+*.emerg	:omusrmsg:<%= scope.lookupvar('rsyslog::usrmsg_users').join(',') %>
 <% else -%>
 *.emerg	*
 <% end -%>


### PR DESCRIPTION
By default the emergency messages are sent to all logged in users
on the machine. rsyslog as a parameter to restrict these message
to a list of user. This new parameter permits to set this list
(to only root for instance). By default the parameter uses "*" (
all users) which was the previously hard coded value).