### PR TITLE
Update rsyslog.conf.erb to reflect documentation

### DIFF
--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -1,4 +1,12 @@
 # file is managed by puppet
+###############################
+#### PRE GLOBAL DIRECTIVES ####
+##############################
+#
+# Set max message size for sending and receiving
+# 
+$MaxMessageSize <%= scope.lookupvar('rsyslog::max_message_size') %>
+
 <% if scope.lookupvar('rsyslog::preserve_fqdn') -%>
 $PreserveFQDN on
 <% end -%>
@@ -21,10 +29,6 @@ $KLogPermitNonKernelFacility on
 ###########################
 #### GLOBAL DIRECTIVES ####
 ###########################
-#
-# Set max message size for sending and receiving
-#
-$MaxMessageSize <%= scope.lookupvar('rsyslog::max_message_size') %>
 
 #
 # Set rate limit for messages received.


### PR DESCRIPTION
I think this directive should be on top, here is a snippet from the documentation:

$MaxMessageSize <size_nbr>, default 8k - allows to specify maximum supported message size (both for sending and receiving). The default should be sufficient for almost all cases. Do not set this below 1k, as it would cause interoperability problems with other syslog implementations.
Important: In order for this directive to work correctly, it must be placed right at the top of rsyslog.conf (before any input is defined).