### PR TITLE
Fixed wrong scope in conditional

### DIFF
--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -29,10 +29,10 @@ $MaxMessageSize <%= scope.lookupvar('rsyslog::max_message_size') %>
 #
 # Set rate limit for messages received.
 # 
-<%- if @system_log_rate_limit_interval -%>
+<%- if scope['rsyslog::system_log_rate_limit_interval'] -%>
 $SystemLogRateLimitInterval <%= scope.lookupvar('rsyslog::system_log_rate_limit_interval') %>
 <%- end -%>
-<%- if @system_log_rate_limit_burst -%>
+<%- if scope['rsyslog::system_log_rate_limit_burst'] -%>
 $SystemLogRateLimitBurst <%= scope.lookupvar('rsyslog::system_log_rate_limit_burst') %>
 <%- end -%>
 


### PR DESCRIPTION
The scope in the conditional is wrong, so it is not possible to define an rate limit or rate limit interval.