### PR TITLE
Add more rsyslog::client queue options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ or send some bitcoins to ```1Na3YFUmdxKxJLiuRXQYJU2kiNqA3KY2j9```
     log_remote                => true,
     spool_size                => '1g',
     spool_timeoutenqueue      => false,
+    spool_queuesize           => 1200000,
+    spool_discardmark         => undef,
+    spool_discardseverity     => undef,
     remote_type               => 'tcp',
     remote_forward_format     => 'RSYSLOG_ForwardFormat',
     log_local                 => false,
@@ -249,6 +252,9 @@ The following lists all the class parameters this module accepts.
     -------------------------------------------------------------------
     log_remote                          true,false          Log Remotely. Defaults to true.
     spool_size                          STRING              Max size for disk queue if remote server failed. Defaults to '1g'.
+    spool_queuesize                     STRING              Maximum number of entries waiting in queue
+    spool_discardmark                   STRING              Start discarding messages after some number of msgs in queue
+    spool_discardseverity               STRING              Which severity of messages to discard when watermark is hit
     remote_type                         'tcp','udp','relp'  Which protocol to use when logging remotely. Defaults to 'tcp'.
     remote_forward_format               STRING              Which forward format for remote servers should be used. Only used if remote_servers is false.
     log_local                           true,false          Log locally. Defaults to false.

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -7,6 +7,9 @@
 # [*log_remote*]
 # [*spool_size*]
 # [*spool_timeoutenqueue*]
+# [*spool_queuesize*]
+# [*spool_discardmark*]
+# [*spool_discardseverity*]
 # [*remote_type*]
 # [*remote_forward_format*]
 # [*log_local*]
@@ -42,6 +45,9 @@ class rsyslog::client (
   $log_remote                = true,
   $spool_size                = '1g',
   $spool_timeoutenqueue      = false,
+  $spool_queuesize           = 1200000,
+  $spool_discardmark         = undef,
+  $spool_discardseverity     = undef,
   $remote_type               = 'tcp',
   $remote_forward_format     = 'RSYSLOG_ForwardFormat',
   $log_local                 = false,
@@ -119,6 +125,10 @@ class rsyslog::client (
       ensure  => $_local_ensure,
       content => template("${module_name}/client/local.conf.erb"),
     }
+  }
+
+  if $spool_discard_severity and ! $spool_discardmark {
+    fail('You cannot use spool discard severity without discard mark set.')
   }
 
   if $ssl and $ssl_ca == undef {

--- a/templates/client/config.conf.erb
+++ b/templates/client/config.conf.erb
@@ -6,6 +6,13 @@ $ActionQueueSaveOnShutdown on   # save messages to disk on shutdown
 <% if scope.lookupvar('rsyslog::client::spool_timeoutenqueue') -%>
 $ActionQueueTimeoutEnqueue <%= scope.lookupvar('rsyslog::client::spool_timeoutenqueue') -%>   # time to wait before discarding on full spool
 <% end -%>
+$ActionQueueSize <%= scope.lookupvar('rsyslog::client::spool_queuesize') %>   # Maximum number of entries waiting in queue
+<% if scope.lookupvar('rsyslog::client::spool_discardmark') -%>
+$ActionQueueDiscardMark <%= scope.lookupvar('rsyslog::client::spool_discardmark') %>  # Start discarding messages after NUM msgs in queue
+<% end -%>
+<% if scope.lookupvar('rsyslog::client::spool_discardseverity') -%>
+$ActionQueueDiscardSeverity <%= scope.lookupvar('rsyslog::client::spool_discardseverity') %>       # Which messages to discard when watermark is hit
+<% end -%>
 $ActionQueueType LinkedList     # run asynchronously
 $ActionResumeRetryCount -1      # infinety retries if host is down
 <% if scope.lookupvar('rsyslog::client::log_templates') and ! scope.lookupvar('rsyslog::client::log_templates').empty?-%>


### PR DESCRIPTION
These additional options allows for a client
message queue limiting and discarding of
overflowing messages:

```
$ActionQueueSize             # Maximum number of entries waiting in queue
$ActionQueueDiscardMark      # Start discarding messages after NUM msgs in queue
$ActionQueueDiscardSeverity  # Which messages to discard when watermark
```
