### PR TITLE
Amazon linux with major version 4 uses RedHat 7 as base

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,11 @@ class rsyslog::params {
         $pgsql_package_name                  = 'rsyslog-pgsql'
         $gnutls_package_name                 = 'rsyslog-gnutls'
         $relp_package_name                   = false
-        $default_config_file                 = 'rsyslog_default'
+        if versioncmp($::operatingsystemmajrelease, '4') >= 0 {
+          $default_config_file                 = 'rsyslog_default_rhel7'
+        } else {
+          $default_config_file                 = 'rsyslog_default'
+        }
         $modules                             = [
           '$ModLoad imuxsock # provides support for local system logging',
           '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',


### PR DESCRIPTION
The rsyslog daemon only starts if we set SYSLOGD_OPTIONS directly, not through ${RSYSLOGD_OPTIONS}, for whatever reason. This fixes it for Amazon Linux as well. At least for the currently latest version.