### PR TITLE
Fix / add amazon linux 2 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,6 +77,9 @@ class rsyslog::params {
         $relp_package_name                   = false
         if versioncmp($::operatingsystemmajrelease, '4') >= 0 {
           $default_config_file                 = 'rsyslog_default_rhel7'
+        }
+        elsif versioncmp($::operatingsystemmajrelease, '2') >= 0 {
+          $default_config_file                 = 'rsyslog_default_rhel7'
         } else {
           $default_config_file                 = 'rsyslog_default'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,11 @@ class rsyslog::params {
         $pgsql_package_name                  = 'rsyslog-pgsql'
         $gnutls_package_name                 = 'rsyslog-gnutls'
         $relp_package_name                   = false
-        $default_config_file                 = 'rsyslog_default'
+        if versioncmp($::operatingsystemmajrelease, '4') >= 0 {
+          $default_config_file                 = 'rsyslog_default_rhel7'
+        } else {
+          $default_config_file                 = 'rsyslog_default'
+        }
         $modules                             = [
           '$ModLoad imuxsock # provides support for local system logging',
           '$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',

--- a/templates/client/local.conf.erb
+++ b/templates/client/local.conf.erb
@@ -13,6 +13,17 @@ auth.info;authpriv.info		/var/log/auth.log
 <% end -%>
 <% end -%>
 <% if @log_local -%>
+<%- if @log_local_custom -%>
+# Custom fragment
+    <%- if @log_local_custom.is_a?(Array) -%>
+        <%- @log_local_custom.each do |line| -%>
+<%= line %>
+        <%- end -%>
+    <%- else -%>
+<%= @log_local_custom %>
+    <%- end -%>
+<%- end -%>
+
 <% if scope.lookupvar('rsyslog::log_style') == 'debian' -%>
 # First some standard log files.  Log by facility.
 #
@@ -115,13 +126,3 @@ uucp,news.crit                 -/var/log/spooler
 local7.*                       -/var/log/boot.log
 <% end -%>
 
-<%- if @log_local_custom -%>
-    # Custom fragment
-    <%- if @log_local_custom.is_a?(Array) -%>
-        <%- @log_local_custom.each do |line| -%>
-            <%= line %>
-        <%- end -%>
-    <%- else -%>
-        <%= @log_local_custom %>
-    <%- end -%>
-<%- end -%>


### PR DESCRIPTION
Amazon linux changed their Major version from 4 (they used the Kernel version, most probably by accident) and change to 2 as it is Amazon linux 2