### PR TITLE
Install rsyslog-logrotate on EL9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class rsyslog (
   $mysql_package_name                  = $rsyslog::params::mysql_package_name,
   $pgsql_package_name                  = $rsyslog::params::pgsql_package_name,
   $gnutls_package_name                 = $rsyslog::params::gnutls_package_name,
+  $logrotate_package_name              = $rsyslog::params::logrotate_package_name,
   $package_status                      = $rsyslog::params::package_status,
   $rsyslog_d                           = $rsyslog::params::rsyslog_d,
   $purge_rsyslog_d                     = $rsyslog::params::purge_rsyslog_d,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,4 +32,10 @@ class rsyslog::install {
     }
   }
 
+  if $rsyslog::logrotate_package_name != false {
+    package { $rsyslog::logrotate_package_name:
+      ensure => $rsyslog::package_status,
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class rsyslog::params {
       $mysql_package_name                  = 'rsyslog-mysql'
       $pgsql_package_name                  = 'rsyslog-pgsql'
       $gnutls_package_name                 = 'rsyslog-gnutls'
+      $logrotate_package_name              = false
       $package_status                      = 'present'
       $rsyslog_d                           = '/etc/rsyslog.d/'
       $rsyslog_conf                        = '/etc/rsyslog.conf'
@@ -75,6 +76,7 @@ class rsyslog::params {
         $pgsql_package_name                  = 'rsyslog-pgsql'
         $gnutls_package_name                 = 'rsyslog-gnutls'
         $relp_package_name                   = false
+        $logrotate_package_name              = false
         $default_config_file                 = 'rsyslog_default'
         $modules                             = [
           '$ModLoad imuxsock # provides support for local system logging',
@@ -92,6 +94,7 @@ class rsyslog::params {
         $mysql_package_name                  = 'rsyslog-mysql'
         $pgsql_package_name                  = 'rsyslog-pgsql'
         $gnutls_package_name                 = 'rsyslog-gnutls'
+        $logrotate_package_name              = false
         $relp_package_name                   = false
         $default_config_file                 = 'rsyslog_default'
         $modules                             = [
@@ -111,6 +114,7 @@ class rsyslog::params {
         $pgsql_package_name                  = 'rsyslog-pgsql'
         $gnutls_package_name                 = 'rsyslog-gnutls'
         $relp_package_name                   = 'rsyslog-relp'
+        $logrotate_package_name              = false
         $default_config_file                 = 'rsyslog_default'
         $modules                             = [
           '$ModLoad imuxsock # provides support for local system logging',
@@ -123,12 +127,14 @@ class rsyslog::params {
         $im_journal_ignore_previous_messages = undef
         $im_journal_statefile                = undef
       }
-      elsif versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+      elsif versioncmp($::operatingsystemmajrelease, '7') == 0 or
+        versioncmp($::operatingsystemmajrelease, '8') == 0 {
         $rsyslog_package_name                = 'rsyslog'
         $mysql_package_name                  = 'rsyslog-mysql'
         $pgsql_package_name                  = 'rsyslog-pgsql'
         $gnutls_package_name                 = 'rsyslog-gnutls'
         $relp_package_name                   = 'rsyslog-relp'
+        $logrotate_package_name              = false
         $default_config_file                 = 'rsyslog_default_rhel7'
         $modules                             = [
           '$ModLoad imuxsock # provides support for local system logging',
@@ -141,6 +147,26 @@ class rsyslog::params {
         $im_journal_ratelimit_burst          = '20000'
         $im_journal_ignore_previous_messages = 'off'
         $im_journal_statefile                = 'imjournal.state'
+      } elsif versioncmp($::operatingsystemmajrelease, '9') >= 0 {
+        $rsyslog_package_name                = 'rsyslog'
+        $mysql_package_name                  = 'rsyslog-mysql'
+        $pgsql_package_name                  = 'rsyslog-pgsql'
+        $gnutls_package_name                 = 'rsyslog-gnutls'
+        $relp_package_name                   = 'rsyslog-relp'
+        $logrotate_package_name              = 'rsyslog-logrotate'
+        $default_config_file                 = 'rsyslog_default_rhel7'
+        $modules                             = [
+          '$ModLoad imuxsock # provides support for local system logging',
+          '$ModLoad imjournal # provides access to the systemd journal',
+          '#$ModLoad imklog   # provides kernel logging support (previously done by rklogd)',
+          '#$ModLoad immark  # provides --MARK-- message capability',
+        ]
+        $omit_local_logging                  = true
+        $im_journal_ratelimit_interval       = '600'
+        $im_journal_ratelimit_burst          = '20000'
+        $im_journal_ignore_previous_messages = 'off'
+        $im_journal_statefile                = 'imjournal.state'
+
       } else {
         $rsyslog_package_name                = 'rsyslog5'
         $mysql_package_name                  = 'rsyslog5-mysql'
@@ -182,6 +208,7 @@ class rsyslog::params {
       $mysql_package_name                  = false
       $pgsql_package_name                  = false
       $gnutls_package_name                 = false
+      $logrotate_package_name              = false
       $package_status                      = 'present'
       $rsyslog_d                           = '/etc/rsyslog.d/'
       $rsyslog_conf                        = '/etc/rsyslog.conf'
@@ -217,6 +244,7 @@ class rsyslog::params {
       $mysql_package_name                  = false
       $pgsql_package_name                  = false
       $gnutls_package_name                 = false
+      $logrotate_package_name              = false
       $package_status                      = 'present'
       $rsyslog_d                           = '/usr/local/etc/rsyslog.d/'
       $rsyslog_conf                        = '/usr/local/etc/rsyslog.conf'
@@ -253,6 +281,7 @@ class rsyslog::params {
           $mysql_package_name                  = 'rsyslog-mysql'
           $pgsql_package_name                  = 'rsyslog-pgsql'
           $gnutls_package_name                 = false
+          $logrotate_package_name              = false
           $package_status                      = 'present'
           $rsyslog_d                           = '/etc/rsyslog.d/'
           $rsyslog_conf                        = '/etc/rsyslog.conf'

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -118,6 +118,47 @@ describe 'rsyslog', type: :class do
         it 'compiles' do
           is_expected.to contain_file('/etc/rsyslog.conf').with_content(%r{\$imjournalRatelimitBurst 20000})
           is_expected.to contain_file('/etc/rsyslog.d/')
+          is_expected.not_to contain_package('rsyslog-logrotate')
+        end
+      end
+    end
+
+    context 'osfamily = RedHat and operatingsystemmajrelease = 8' do
+      let :facts do
+        default_facts.merge!(
+          osfamily: 'RedHat',
+          operatingsystem: 'RedHat',
+          operatingsystemmajrelease: '8'
+        )
+      end
+
+      context 'default usage (osfamily = RedHat)' do
+        let(:title) { 'rsyslog-basic' }
+
+        it 'compiles' do
+          is_expected.to contain_file('/etc/rsyslog.conf').with_content(%r{\$imjournalRatelimitBurst 20000})
+          is_expected.to contain_file('/etc/rsyslog.d/')
+          is_expected.not_to contain_package('rsyslog-logrotate')
+        end
+      end
+    end
+
+    context 'osfamily = RedHat and operatingsystemmajrelease = 9' do
+      let :facts do
+        default_facts.merge!(
+          osfamily: 'RedHat',
+          operatingsystem: 'RedHat',
+          operatingsystemmajrelease: '9'
+        )
+      end
+
+      context 'default usage (osfamily = RedHat)' do
+        let(:title) { 'rsyslog-basic' }
+
+        it 'compiles' do
+          is_expected.to contain_file('/etc/rsyslog.conf').with_content(%r{\$imjournalRatelimitBurst 20000})
+          is_expected.to contain_file('/etc/rsyslog.d/')
+          is_expected.to contain_package('rsyslog-logrotate').with_ensure('present')
         end
       end
     end
@@ -136,6 +177,7 @@ describe 'rsyslog', type: :class do
         it 'compiles' do
           is_expected.to contain_file('/etc/rsyslog.conf')
           is_expected.to contain_file('/etc/rsyslog.d/')
+          is_expected.not_to contain_package('rsyslog-logrotate')
         end
       end
     end


### PR DESCRIPTION
On EL9 the `/etc/logrotate.d/rsyslog` has been split out into its own package.

New parameter is added which is set for os.family == RedHat 9 and newer to install this package.

RPM changelog contians:

```
- Split out logrotate config and dependency into a subpackage
  resolves: rhbz#1992155
```

* https://bugzilla.redhat.com/show_bug.cgi?id=1992155