### PR TITLE
Tweaks to enable us to support rhel9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,8 +41,8 @@
 # @param rsyslog_default_file
 #   `rsyslog_d` file template to use
 #
-# @param rsyslog_default_use_caller_module
-#   `rsyslog_d` use the called module for templates
+# @param rsyslog_default_file_absolute_path
+#   `rsyslog_d` use the absolute template path
 #
 # @param run_user
 #   Which user rsyslog should run as
@@ -153,7 +153,7 @@ class rsyslog (
   String[1] $rsyslog_conf_template_file = "${module_name}/rsyslog.conf.erb",
   Stdlib::Absolutepath $rsyslog_default = $rsyslog::params::rsyslog_default,
   String[1] $rsyslog_default_file = $rsyslog::params::default_config_file,
-  Boolean $rsyslog_default_use_caller_module = false,
+  Boolean $rsyslog_default_file_absolute_path = false,
   String[1] $run_user = $rsyslog::params::run_user,
   String[1] $run_group = $rsyslog::params::run_group,
   String[1] $log_user = $rsyslog::params::log_user,
@@ -212,8 +212,7 @@ class rsyslog (
     require => File[$rsyslog_d],
   }
 
-  if($rsyslog_default_use_caller_module == false ) {
-    Notify{"Caller module ${caller_module_name} - cake": }
+  if($rsyslog_default_file_absolute_path == false ) {
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',
@@ -223,7 +222,6 @@ class rsyslog (
       require => File[$rsyslog_conf],
     }
   } else {
-    Notify{"Caller module ${module_name}": }
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@
 #   `rsyslog_d` file template to use
 #
 # @param rsyslog_default_file_absolute_path
-#   `rsyslog_d` use the absolute template path
+#   `rsyslog_d` Use rsyslog_default_file as the absolute template path
 #
 # @param run_user
 #   Which user rsyslog should run as

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,7 +223,7 @@ class rsyslog (
       require => File[$rsyslog_conf],
     }
   } else {
-    Notify("Caller module ${caller_module_name}")
+    Notify("Caller module ${module_name}")
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -213,6 +213,7 @@ class rsyslog (
   }
 
   if($rsyslog_default_use_caller_module == true ) {
+    Notify("Caller module ${caller_module_name}")
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',
@@ -222,6 +223,7 @@ class rsyslog (
       require => File[$rsyslog_conf],
     }
   } else {
+    Notify("Caller module ${caller_module_name}")
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -213,7 +213,7 @@ class rsyslog (
   }
 
   if($rsyslog_default_use_caller_module == true ) {
-    Notify("Caller module ${caller_module_name} - cake")
+    Notify{"Caller module ${caller_module_name} - cake": }
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',
@@ -223,7 +223,7 @@ class rsyslog (
       require => File[$rsyslog_conf],
     }
   } else {
-    Notify("Caller module ${module_name} - Not cake")
+    Notify{"Caller module ${module_name}": }
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -212,13 +212,13 @@ class rsyslog (
     require => File[$rsyslog_d],
   }
 
-  if($rsyslog_default_use_caller_module == true ) {
+  if($rsyslog_default_use_caller_module == false ) {
     Notify{"Caller module ${caller_module_name} - cake": }
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',
       group   => $run_group,
-      content => template("${caller_module_name}/${rsyslog_default_file}.erb"),
+      content => template("${rsyslog_default_file}.erb"),
       notify  => Service[$service_name],
       require => File[$rsyslog_conf],
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,9 @@
 # @param rsyslog_default_file
 #   `rsyslog_d` file template to use
 #
+# @param rsyslog_default_use_caller_module
+#   `rsyslog_d` use the called module for templates
+#
 # @param run_user
 #   Which user rsyslog should run as
 #
@@ -150,6 +153,7 @@ class rsyslog (
   String[1] $rsyslog_conf_template_file = "${module_name}/rsyslog.conf.erb",
   Stdlib::Absolutepath $rsyslog_default = $rsyslog::params::rsyslog_default,
   String[1] $rsyslog_default_file = $rsyslog::params::default_config_file,
+  Boolean $rsyslog_default_use_caller_module = false,
   String[1] $run_user = $rsyslog::params::run_user,
   String[1] $run_group = $rsyslog::params::run_group,
   String[1] $log_user = $rsyslog::params::log_user,
@@ -208,13 +212,24 @@ class rsyslog (
     require => File[$rsyslog_d],
   }
 
-  file { $rsyslog_default:
-    ensure  => file,
-    owner   => 'root',
-    group   => $run_group,
-    content => template("${module_name}/${rsyslog_default_file}.erb"),
-    notify  => Service[$service_name],
-    require => File[$rsyslog_conf],
+  if($rsyslog_default_use_caller_module == true ) {
+    file { $rsyslog_default:
+      ensure  => file,
+      owner   => 'root',
+      group   => $run_group,
+      content => template("${caller_module_name}/${rsyslog_default_file}.erb"),
+      notify  => Service[$service_name],
+      require => File[$rsyslog_conf],
+    }
+  } else {
+    file { $rsyslog_default:
+      ensure  => file,
+      owner   => 'root',
+      group   => $run_group,
+      content => template("${module_name}/${rsyslog_default_file}.erb"),
+      notify  => Service[$service_name],
+      require => File[$rsyslog_conf],
+    }
   }
 
   file { $spool_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -213,7 +213,7 @@ class rsyslog (
   }
 
   if($rsyslog_default_use_caller_module == true ) {
-    Notify("Caller module ${caller_module_name}")
+    Notify("Caller module ${caller_module_name} - cake")
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',
@@ -223,7 +223,7 @@ class rsyslog (
       require => File[$rsyslog_conf],
     }
   } else {
-    Notify("Caller module ${module_name}")
+    Notify("Caller module ${module_name} - Not cake")
     file { $rsyslog_default:
       ensure  => file,
       owner   => 'root',

--- a/templates/client/remote.conf.erb
+++ b/templates/client/remote.conf.erb
@@ -38,7 +38,7 @@
 <% else -%>
 <% dropaction = '' -%>
 <% end -%>
-<%= pattern %> to <%= host %> via <%= server['protocol'].downcase %> on <%= port %> using <%=format_type %> format.
+# Sending logs that match <%= pattern %> to <%= host %> via <%= server['protocol'].downcase %> on <%= port %> using <%=format_type %> format.
 <%= pattern %> <%= protocol %><%= host %>:<%= port %><%= format %>
 <%= dropaction %>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
These are some tweaks we made to a fork of the project to allow us to use this in rhel9, nothing major but it made it workable for us and I suspect it may be workable for others.

#### This Pull Request (PR) fixes the following issues
* Added rsyslog_default_file_absolute_path option to allow the path provided for the default_file option to be absolute so it could be stored in different module without changing the current default mode of operation as we found the current template results in the rsyslog service failing under rhel9.

* Corrected a typo that seems to have some in with the last commit when forked that essentially removed the hash from a comment breaking rsyslogd.
